### PR TITLE
remove level of detail from vehicles and introduce difference route types

### DIFF
--- a/assets/drt/config.yml
+++ b/assets/drt/config.yml
@@ -23,6 +23,8 @@ modules:
     end_time: 84600
     sample_size: 1
     stuck_threshold: 30
+    main_modes:
+      - car
   drt:
     type: Drt
     services:

--- a/src/bin/convert_to_binary.rs
+++ b/src/bin/convert_to_binary.rs
@@ -54,7 +54,8 @@ fn compute_computational_weights(pop: &Population) -> IntMap<u64, u32> {
         .values()
         .flat_map(|p| p.plan.as_ref().unwrap().legs.iter())
         .filter(|leg| leg.route.is_some())
-        .flat_map(|leg| leg.route.as_ref().unwrap().route.iter())
+        .filter_map(|leg| leg.route.as_ref()?.as_network())
+        .flat_map(|n| n.route.iter())
         .fold(IntMap::new(), |mut map, link_id| {
             map.entry(*link_id)
                 .and_modify(|counter| *counter += 1)

--- a/src/simulation/engines/teleportation_engine.rs
+++ b/src/simulation/engines/teleportation_engine.rs
@@ -52,7 +52,7 @@ impl TeleportationEngine {
             let mode: Id<String> = Id::get(leg.mode);
             self.events.borrow_mut().publish_event(
                 now,
-                &Event::new_travelled(agent.id(), route.distance, mode.internal()),
+                &Event::new_travelled(agent.id(), route.as_generic().distance, mode.internal()),
             );
             vehicle.register_vehicle_exited();
         }

--- a/src/simulation/messaging/communication/message_broker.rs
+++ b/src/simulation/messaging/communication/message_broker.rs
@@ -377,6 +377,7 @@ mod tests {
             end_time: 0,
             sample_size: 0.0,
             stuck_threshold: 0,
+            main_modes: vec![],
         };
         let broker = NetMessageBroker::new(
             Rc::new(communicator),

--- a/src/simulation/network/link.rs
+++ b/src/simulation/network/link.rs
@@ -381,7 +381,7 @@ mod sim_link_tests {
     use crate::simulation::network::link::{LocalLink, SimLink};
     use crate::simulation::wire_types::messages::Vehicle;
     use crate::test_utils;
-    use crate::test_utils::create_agent;
+    use crate::test_utils::create_agent_without_route;
 
     #[test]
     fn storage_cap_consumed() {
@@ -396,7 +396,7 @@ mod sim_link_tests {
             Id::new_internal(1),
             Id::new_internal(2),
         ));
-        let agent = create_agent(1, vec![]);
+        let agent = create_agent_without_route(1);
         let vehicle = Vehicle::new(1, 0, 10., 1.5, Some(agent));
 
         link.push_veh(vehicle, 0);
@@ -418,7 +418,7 @@ mod sim_link_tests {
             Id::new_internal(1),
             Id::new_internal(2),
         ));
-        let agent = create_agent(1, vec![]);
+        let agent = create_agent_without_route(1);
         let vehicle = Vehicle::new(1, 0, 10., 1.5, Some(agent));
 
         link.push_veh(vehicle, 0);
@@ -450,9 +450,9 @@ mod sim_link_tests {
             Id::new_internal(2),
         ));
 
-        let agent1 = create_agent(1, vec![]);
+        let agent1 = create_agent_without_route(1);
         let vehicle1 = Vehicle::new(1, 0, 10., 1.5, Some(agent1));
-        let agent2 = create_agent(2, vec![]);
+        let agent2 = create_agent_without_route(2);
         let vehicle2 = Vehicle::new(2, 0, 10., 1.5, Some(agent2));
 
         link.push_veh(vehicle1, 0);
@@ -490,7 +490,7 @@ mod sim_link_tests {
             Id::new_internal(2),
         ));
 
-        let agent1 = create_agent(1, vec![]);
+        let agent1 = create_agent_without_route(1);
         let vehicle1 = Vehicle::new(1, 0, 10., 1.5, Some(agent1));
 
         link.push_veh(vehicle1, 0);
@@ -520,9 +520,9 @@ mod sim_link_tests {
             Id::new_internal(0),
         ));
 
-        let agent1 = create_agent(1, vec![]);
+        let agent1 = create_agent_without_route(1);
         let vehicle1 = Vehicle::new(id1, 0, 10., 1., Some(agent1));
-        let agent2 = create_agent(1, vec![]);
+        let agent2 = create_agent_without_route(1);
         let vehicle2 = Vehicle::new(id2, 0, 10., 1., Some(agent2));
 
         link.push_veh(vehicle1, 0);
@@ -549,6 +549,7 @@ mod sim_link_tests {
             end_time: 0,
             sample_size: 1.0,
             stuck_threshold,
+            main_modes: vec![],
         };
         let mut link = SimLink::Local(LocalLink::new(
             Id::create("stuck-link"),
@@ -587,6 +588,7 @@ mod sim_link_tests {
             end_time: 0,
             sample_size: 1.0,
             stuck_threshold,
+            main_modes: vec![],
         };
         let mut link = SimLink::Local(LocalLink::new(
             Id::create("stuck-link"),
@@ -628,7 +630,7 @@ mod out_link_tests {
     use crate::simulation::network::link::{SimLink, SplitOutLink};
     use crate::simulation::network::storage_cap::StorageCap;
     use crate::simulation::wire_types::messages::Vehicle;
-    use crate::test_utils::create_agent;
+    use crate::test_utils::create_agent_without_route;
 
     #[test]
     fn push_and_take() {
@@ -640,9 +642,9 @@ mod out_link_tests {
         });
         let id1 = 42;
         let id2 = 43;
-        let agent1 = create_agent(1, vec![]);
+        let agent1 = create_agent_without_route(1);
         let vehicle1 = Vehicle::new(id1, 0, 10., 1., Some(agent1));
-        let agent2 = create_agent(1, vec![]);
+        let agent2 = create_agent_without_route(1);
         let vehicle2 = Vehicle::new(id2, 0, 10., 1., Some(agent2));
 
         link.push_veh(vehicle1, 0);

--- a/src/simulation/vehicles/io.rs
+++ b/src/simulation/vehicles/io.rs
@@ -5,11 +5,11 @@ use tracing::info;
 
 use crate::simulation;
 use crate::simulation::id::Id;
-use crate::simulation::io::attributes::{Attr, Attrs};
+use crate::simulation::io::attributes::Attrs;
 use crate::simulation::io::xml;
 use crate::simulation::vehicles::garage::Garage;
 use crate::simulation::wire_types::messages::Vehicle;
-use crate::simulation::wire_types::vehicles::{LevelOfDetail, VehicleType, VehiclesContainer};
+use crate::simulation::wire_types::vehicles::{VehicleType, VehiclesContainer};
 
 pub fn from_file(path: &Path) -> Garage {
     if path.extension().unwrap().eq("binpb") {
@@ -54,32 +54,23 @@ fn write_to_xml(garage: &Garage, path: &Path) {
     let veh_types = garage
         .vehicle_types
         .values()
-        .map(|t| {
-            let attrs = Attrs {
-                attributes: vec![Attr {
-                    name: "lod".to_string(),
-                    class: "java.lang.String".to_string(),
-                    value: t.lod().as_str_name().to_owned(),
-                }],
-            };
-            IOVehicleType {
-                id: Id::<VehicleType>::get(t.id).external().to_owned(),
-                description: None,
-                capacity: None,
-                length: Some(IODimension { meter: t.length }),
-                width: Some(IODimension { meter: t.width }),
-                maximum_velocity: Some(IOVelocity {
-                    meter_per_second: t.max_v,
-                }),
-                engine_information: None,
-                cost_information: None,
-                passenger_car_equivalents: Some(IOPassengerCarEquivalents { pce: t.pce }),
-                network_mode: Some(IONetworkMode {
-                    network_mode: Id::<String>::get(t.net_mode).external().to_owned(),
-                }),
-                flow_efficiency_factor: Some(IOFowEfficiencyFactor { factor: t.fef }),
-                attributes: Some(attrs),
-            }
+        .map(|t| IOVehicleType {
+            id: Id::<VehicleType>::get(t.id).external().to_owned(),
+            description: None,
+            capacity: None,
+            length: Some(IODimension { meter: t.length }),
+            width: Some(IODimension { meter: t.width }),
+            maximum_velocity: Some(IOVelocity {
+                meter_per_second: t.max_v,
+            }),
+            engine_information: None,
+            cost_information: None,
+            passenger_car_equivalents: Some(IOPassengerCarEquivalents { pce: t.pce }),
+            network_mode: Some(IONetworkMode {
+                network_mode: Id::<String>::get(t.net_mode).external().to_owned(),
+            }),
+            flow_efficiency_factor: Some(IOFowEfficiencyFactor { factor: t.fef }),
+            attributes: None,
         })
         .collect();
 
@@ -126,21 +117,6 @@ fn add_io_veh_type(garage: &mut Garage, io_veh_type: IOVehicleType) {
     let id: Id<VehicleType> = Id::create(&io_veh_type.id);
     let net_mode: Id<String> =
         Id::create(&io_veh_type.network_mode.unwrap_or_default().network_mode);
-    let lod = if let Some(attr) = io_veh_type
-        .attributes
-        .unwrap_or_default()
-        .attributes
-        .iter()
-        .find(|&attr| attr.name.eq("lod"))
-    {
-        match attr.value.to_lowercase().as_str() {
-            "teleported" => LevelOfDetail::Teleported,
-            "network" => LevelOfDetail::Network,
-            _ => LevelOfDetail::Network,
-        }
-    } else {
-        LevelOfDetail::Network
-    };
 
     let veh_type = VehicleType {
         id: id.internal(),
@@ -159,7 +135,6 @@ fn add_io_veh_type(garage: &mut Garage, io_veh_type: IOVehicleType) {
             .unwrap_or_default()
             .factor,
         net_mode: net_mode.internal(),
-        lod: lod as i32,
     };
     garage.add_veh_type(veh_type);
 }
@@ -306,7 +281,7 @@ mod test {
         add_io_veh_type, from_file, to_file, IODimension, IOFowEfficiencyFactor, IONetworkMode,
         IOPassengerCarEquivalents, IOVehicleDefinitions, IOVehicleType, IOVelocity,
     };
-    use crate::simulation::wire_types::vehicles::{LevelOfDetail, VehicleType};
+    use crate::simulation::wire_types::vehicles::VehicleType;
 
     #[test]
     fn from_string_empty_type() {
@@ -408,7 +383,6 @@ mod test {
             pce: 20.0,
             fef: 0.3,
             net_mode: Id::<String>::create("some network type 🚕").internal(),
-            lod: LevelOfDetail::Teleported as i32,
         });
         garage.add_veh_by_type(&Id::create("some-person"), &Id::get_from_ext("some-type"));
 
@@ -432,7 +406,6 @@ mod test {
             pce: 20.0,
             fef: 0.3,
             net_mode: Id::<String>::create("some network type 🚕").internal(),
-            lod: LevelOfDetail::Teleported as i32,
         });
         garage.add_veh_by_type(&Id::create("some-person"), &Id::get_from_ext("some-type"));
 
@@ -469,8 +442,6 @@ mod test {
 
         let veh_type_opt = garage.vehicle_types.values().next();
         assert!(veh_type_opt.is_some());
-        let veh_type = veh_type_opt.unwrap();
-        assert!(matches!(veh_type.lod(), LevelOfDetail::Network));
     }
 
     #[test]
@@ -504,7 +475,6 @@ mod test {
         let veh_type_opt = garage.vehicle_types.values().next();
         assert!(veh_type_opt.is_some());
         let veh_type = veh_type_opt.unwrap();
-        assert!(matches!(veh_type.lod(), LevelOfDetail::Teleported));
         assert_eq!(veh_type.max_v, 100.);
         assert_eq!(veh_type.width, 5.0);
         assert_eq!(veh_type.length, 10.);

--- a/src/simulation/wire_types/population.proto
+++ b/src/simulation/wire_types/population.proto
@@ -34,12 +34,36 @@ message Leg {
   uint64 routing_mode = 2;
   optional uint32 dep_time = 3;
   uint32 trav_time = 4;
-  Route route = 5;
   map<string, general.AttributeValue> attributes = 6;
+  oneof route {
+    GenericRoute generic_route = 7;
+    NetworkRoute network_route = 8;
+    PtRoute pt_route = 9;
+  };
 }
 
-message Route {
-  uint64 veh_id = 1;
-  double distance = 2;
-  repeated uint64 route = 3;
+message GenericRoute {
+  uint64 start_link = 1;
+  uint64 end_link = 2;
+  uint64 trav_time = 3;
+  double distance = 4;
+  uint64 veh_id = 5;
+}
+
+message NetworkRoute {
+  GenericRoute delegate = 1;
+  repeated uint64 route = 2;
+}
+
+message PtRoute {
+  GenericRoute delegate = 1;
+  PtInformation information = 2;
+}
+
+message PtInformation {
+  string transitRouteId = 1;
+  uint64 boardingTime = 2;
+  string transitLine = 3;
+  string accessFacilityId = 4;
+  string egressFacilityId = 5;
 }

--- a/src/simulation/wire_types/vehicles.proto
+++ b/src/simulation/wire_types/vehicles.proto
@@ -16,10 +16,4 @@ message VehicleType {
   float pce = 5;
   float fef = 6;
   uint64 net_mode = 7;
-  LevelOfDetail lod = 8;
-}
-
-enum LevelOfDetail {
-  Network = 0;
-  Teleported = 1;
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -4,16 +4,29 @@ use std::path::PathBuf;
 use crate::simulation::config;
 use crate::simulation::id::Id;
 use crate::simulation::wire_types::messages::{PlanLogic, SimulationAgent, SimulationAgentLogic};
-use crate::simulation::wire_types::population::{Activity, Leg, Person, Plan, Route};
-use crate::simulation::wire_types::vehicles::{LevelOfDetail, VehicleType};
+use crate::simulation::wire_types::population::leg::Route;
+use crate::simulation::wire_types::population::{
+    Activity, GenericRoute, Leg, NetworkRoute, Person, Plan,
+};
+use crate::simulation::wire_types::vehicles::VehicleType;
+
+pub fn create_agent_without_route(id: u64) -> SimulationAgent {
+    //inserting a dummy route
+    create_agent(id, vec![0, 1])
+}
 
 pub fn create_agent(id: u64, route: Vec<u64>) -> SimulationAgent {
-    let route = Route {
-        veh_id: id,
-        distance: 0.0,
+    let route = NetworkRoute {
+        delegate: Some(GenericRoute {
+            start_link: *route.first().unwrap(),
+            end_link: *route.last().unwrap(),
+            trav_time: 0,
+            distance: 0.0,
+            veh_id: id,
+        }),
         route,
     };
-    let leg = Leg::new(route, 0, 0, None);
+    let leg = Leg::new(Route::NetworkRoute(route), 0, 0, None);
     let act = Activity::new(0., 0., 0, 1, None, None, None);
     let mut plan = Plan::new();
     plan.add_act(act);
@@ -51,7 +64,6 @@ pub fn create_vehicle_type(id: &Id<VehicleType>, net_mode: Id<String>) -> Vehicl
         pce: 0.0,
         fef: 0.0,
         net_mode: net_mode.internal(),
-        lod: LevelOfDetail::Network as i32,
     }
 }
 
@@ -61,5 +73,6 @@ pub fn config() -> config::Simulation {
         end_time: 0,
         sample_size: 1.0,
         stuck_threshold: u32::MAX,
+        main_modes: vec![String::from("car")],
     }
 }


### PR DESCRIPTION
This PR introduces the simulation of PT as teleported mode. Therefore, the `LevelOfDetail` was removed from the vehicles and instead encoded as different route types as in conventional MATSim. 

Closes #149.

