### PR TITLE
Introduce rolling horizon replanning

### DIFF
--- a/src/simulation/controller/mod.rs
+++ b/src/simulation/controller/mod.rs
@@ -16,7 +16,7 @@ use crate::simulation::messaging::communication::SimCommunicator;
 use crate::simulation::messaging::events::EventsPublisher;
 use crate::simulation::network::global_network::Network;
 use crate::simulation::scenario::Scenario;
-use crate::simulation::simulation::Simulation;
+use crate::simulation::simulation::{Simulation, SimulationBuilder};
 use crate::simulation::{id, io};
 use nohash_hasher::IntMap;
 use tracing::info;
@@ -55,7 +55,7 @@ fn execute_partition<C: SimCommunicator>(comm: C, args: &CommandLineArgs) {
     );
 
     let mut simulation: Simulation<C> =
-        Simulation::new(config, scenario, net_message_broker, events);
+        SimulationBuilder::new(config, scenario, net_message_broker, events).build();
 
     // Wait for all processes to arrive at this barrier. This is important to ensure that the
     // instrumentation of the simulation.run() method does not include any time it takes to

--- a/src/simulation/engines/activity_engine.rs
+++ b/src/simulation/engines/activity_engine.rs
@@ -1,22 +1,29 @@
+use crate::simulation::config::Config;
 use crate::simulation::id::Id;
 use crate::simulation::messaging::events::EventsPublisher;
-use crate::simulation::time_queue::MutTimeQueue;
+use crate::simulation::time_queue::{EndTime, TimeQueue};
 use crate::simulation::wire_types::events::Event;
 use crate::simulation::wire_types::messages::SimulationAgent;
 use std::cell::RefCell;
 use std::rc::Rc;
 
 pub struct ActivityEngine {
-    activity_q: MutTimeQueue<SimulationAgent>,
+    asleep_q: TimeQueue<AsleepSimulationAgent>,
+    awake_q: Vec<AsleepSimulationAgent>,
     events: Rc<RefCell<EventsPublisher>>,
 }
 
 impl ActivityEngine {
-    pub fn new(
-        activity_q: MutTimeQueue<SimulationAgent>,
+    fn new(
+        asleep_q: TimeQueue<AsleepSimulationAgent>,
+        awake_q: Vec<AsleepSimulationAgent>,
         events: Rc<RefCell<EventsPublisher>>,
     ) -> Self {
-        ActivityEngine { activity_q, events }
+        ActivityEngine {
+            asleep_q,
+            awake_q,
+            events,
+        }
     }
 
     pub(crate) fn do_step(
@@ -25,38 +32,119 @@ impl ActivityEngine {
         agents: Vec<SimulationAgent>,
     ) -> Vec<SimulationAgent> {
         for agent in agents {
-            self.receive_agent(now, agent);
+            self.receive_agent(now, AsleepSimulationAgent::build(agent, now));
         }
 
-        self.wake_up(now)
-    }
+        let wake_up = self.wake_up(now);
+        self.inform(now);
+        let end = self.end(now);
 
-    pub(crate) fn receive_agent(&mut self, now: u32, agent: SimulationAgent) {
-        // emmit act start event
-        let act = agent.curr_act();
-        let act_type: Id<String> = Id::get(act.act_type);
-        self.events.borrow_mut().publish_event(
-            now,
-            &Event::new_act_start(agent.id(), act.link_id, act_type.internal()),
-        );
-        self.activity_q.add(agent, now);
-    }
-
-    pub fn agents(&mut self) -> impl Iterator<Item = &mut SimulationAgent> {
-        self.activity_q.iter_mut()
-    }
-
-    fn wake_up(&mut self, now: u32) -> Vec<SimulationAgent> {
-        let mut agents = self.activity_q.pop(now);
-
-        for agent in agents.iter_mut() {
+        let mut res = Vec::with_capacity(wake_up.len() + end.len());
+        for agent in wake_up.into_iter().chain(end.into_iter()) {
             let act_type: Id<String> = Id::get(agent.curr_act().act_type);
             self.events.borrow_mut().publish_event(
                 now,
                 &Event::new_act_end(agent.id(), agent.curr_act().link_id, act_type.internal()),
             );
+            res.push(agent);
         }
+        res
+    }
 
+    fn receive_agent(&mut self, now: u32, agent: AsleepSimulationAgent) {
+        // emmit act start event
+        let act = agent.agent.curr_act();
+        let act_type: Id<String> = Id::get(act.act_type);
+        self.events.borrow_mut().publish_event(
+            now,
+            &Event::new_act_start(agent.agent.id(), act.link_id, act_type.internal()),
+        );
+        self.asleep_q.add(agent, now);
+    }
+
+    fn wake_up(&mut self, now: u32) -> Vec<SimulationAgent> {
+        let mut end_agents = Vec::new();
+        let wake_up = self.asleep_q.pop(now);
+
+        // for fast turnaround, agents whose end time is already reached are directly returned and not put into the awake queue
+        for agent in wake_up {
+            if agent.end_time(now) <= now {
+                end_agents.push(agent.agent);
+            } else {
+                self.awake_q.push(agent);
+            }
+        }
+        end_agents
+    }
+
+    fn end(&mut self, now: u32) -> Vec<SimulationAgent> {
+        let mut agents = Vec::new();
+
+        let mut i = 0;
+        while i < self.awake_q.len() {
+            let agent = &self.awake_q[i];
+            if agent.end_time(now) <= now {
+                let removed = self.awake_q.swap_remove(i);
+                agents.push(removed.agent);
+            } else {
+                i += 1;
+            }
+        }
         agents
+    }
+
+    fn inform(&mut self, _now: u32) {
+        // Go through all awakened agents and inform them about current time.
+        // Provide structs that are needed for replanning.
+    }
+}
+
+pub struct ActivityEngineBuilder<'c> {
+    agents: Vec<SimulationAgent>,
+    events: Rc<RefCell<EventsPublisher>>,
+    config: &'c Config,
+}
+
+impl<'c> ActivityEngineBuilder<'c> {
+    pub fn new(
+        agents: Vec<SimulationAgent>,
+        events: Rc<RefCell<EventsPublisher>>,
+        config: &'c Config,
+    ) -> Self {
+        ActivityEngineBuilder {
+            agents,
+            events,
+            config,
+        }
+    }
+
+    pub fn build(self) -> ActivityEngine {
+        let now = self.config.simulation().start_time;
+
+        let mut asleep = TimeQueue::new();
+        for agent in self.agents {
+            asleep.add(AsleepSimulationAgent::build(agent, now), now);
+        }
+        let awake_q = Vec::new();
+        ActivityEngine::new(asleep, awake_q, self.events)
+    }
+}
+
+struct AsleepSimulationAgent {
+    agent: SimulationAgent,
+    wakeup_time: u32,
+}
+
+impl AsleepSimulationAgent {
+    fn build(agent: SimulationAgent, now: u32) -> Self {
+        let wakeup_time = agent.wakeup_time(now);
+
+        AsleepSimulationAgent { agent, wakeup_time }
+    }
+}
+
+impl EndTime for AsleepSimulationAgent {
+    fn end_time(&self, _now: u32) -> u32 {
+        self.wakeup_time
     }
 }

--- a/src/simulation/mod.rs
+++ b/src/simulation/mod.rs
@@ -1,3 +1,4 @@
+mod computational_environment;
 pub mod config;
 pub mod controller;
 pub mod engines;

--- a/src/simulation/population/io.rs
+++ b/src/simulation/population/io.rs
@@ -48,7 +48,7 @@ pub fn to_file(population: &Population, path: &Path) {
 fn load_from_xml(path: &Path, garage: &mut Garage) -> HashMap<Id<Person>, Person> {
     let io_pop = IOPopulation::from_file(path.to_str().unwrap());
     create_ids(&io_pop, garage);
-    create_population(&io_pop)
+    create_population(io_pop)
 }
 
 fn write_to_xml(_population: &Population, _path: &Path) {
@@ -156,9 +156,9 @@ fn create_ids(io_pop: &IOPopulation, garage: &mut Garage) {
         });
 }
 
-fn create_population(io_pop: &IOPopulation) -> HashMap<Id<Person>, Person> {
+fn create_population(io_pop: IOPopulation) -> HashMap<Id<Person>, Person> {
     let mut result = HashMap::new();
-    for io_person in &io_pop.persons {
+    for io_person in io_pop.persons {
         let person = Person::from_io(io_person);
         result.insert(Id::get(person.id()), person);
     }
@@ -295,12 +295,8 @@ pub struct IOPerson {
     pub id: String,
     #[serde(rename = "plan")]
     pub plans: Vec<IOPlan>,
-}
-
-impl IOPerson {
-    pub fn selected_plan(&self) -> &IOPlan {
-        self.plans.iter().find(|p| p.selected).unwrap()
-    }
+    #[serde(rename = "attributes", skip_serializing_if = "Option::is_none")]
+    pub attributes: Option<Attrs>,
 }
 
 #[derive(Debug, Deserialize, PartialEq)]

--- a/src/simulation/wire_types/population.proto
+++ b/src/simulation/wire_types/population.proto
@@ -12,6 +12,7 @@ message Person {
   uint64 id = 1;
   uint32 curr_plan_elem = 2;
   Plan plan = 3;
+  map<string, general.AttributeValue> attributes = 4;
 }
 
 message Plan {

--- a/tests/test_simulation.rs
+++ b/tests/test_simulation.rs
@@ -26,7 +26,7 @@ use rust_q_sim::simulation::network::sim_network::SimNetworkPartition;
 use rust_q_sim::simulation::population::population_data::Population;
 use rust_q_sim::simulation::replanning::routing::travel_time_collector::TravelTimeCollector;
 use rust_q_sim::simulation::scenario::Scenario;
-use rust_q_sim::simulation::simulation::Simulation;
+use rust_q_sim::simulation::simulation::SimulationBuilder;
 use rust_q_sim::simulation::vehicles::garage::Garage;
 use rust_q_sim::simulation::wire_types::events::Event;
 
@@ -127,7 +127,7 @@ pub fn execute_sim<C: SimCommunicator + 'static>(
         network_partition: sim_net,
     };
 
-    let mut sim = Simulation::new(config, scenario, broker, events);
+    let mut sim = SimulationBuilder::new(config, scenario, broker, events).build();
     sim.run();
 }
 


### PR DESCRIPTION
introduce asleep and awake agents in activity engine; read attribute of next leg to decide on replanning