### PR TITLE
Changed Rust Version (Channel) from 'stable' to '1.86.0'

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "stable"
+channel = "1.86.0"


### PR DESCRIPTION
Rust Version 1.89.0 created some issues so i set the rust version to 1.86.0. Otherwise it was not possible to downgrade the rust version.