### PR TITLE
Change to the URL for URL testing.

### DIFF
--- a/tests/test_3_links_url.rs
+++ b/tests/test_3_links_url.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 mod test_simulation;
 
 const BASE_URL: &str =
-    "https://raw.githubusercontent.com/matsim-vsp/parallel_qsim_rust/refs/heads/43-load-files-via-url/tests/resources/3-links-url";
+    "https://raw.githubusercontent.com/matsim-vsp/parallel_qsim_rust/refs/heads/main/tests/resources/3-links-url";
 
 #[test]
 fn load_files_from_url_have_content() {


### PR DESCRIPTION
Since the feature branch has been deleted, the URL must now point to the main branch (test_3_links_url.rs).

The pull request must be merged without running the tests because the tests only run on the main branch.