### PR TITLE
Multiple routing services

### DIFF
--- a/rust_qsim/examples/local_qsim_routing.rs
+++ b/rust_qsim/examples/local_qsim_routing.rs
@@ -23,7 +23,8 @@ fn main() {
     let config = Config::from(args.delegate);
 
     let (router_handle, send, send_sd) =
-        RoutingServiceAdapterFactory::new(&args.router_ip, config.clone()).spawn_thread("router");
+        RoutingServiceAdapterFactory::new(vec![&args.router_ip], config.clone())
+            .spawn_thread("router");
 
     let mut services = ExternalServices::default();
     services.insert(ExternalServiceType::Routing("pt".into()), send.into());

--- a/rust_qsim/examples/local_qsim_routing.rs
+++ b/rust_qsim/examples/local_qsim_routing.rs
@@ -1,12 +1,13 @@
 use clap::Parser;
 use rust_qsim::external_services::routing::RoutingServiceAdapterFactory;
-use rust_qsim::external_services::{AdapterHandleBuilder, ExternalServiceType};
+use rust_qsim::external_services::{AdapterHandleBuilder, AsyncExecutor, ExternalServiceType};
 use rust_qsim::simulation::config::Config;
 use rust_qsim::simulation::controller;
 use rust_qsim::simulation::controller::local_controller::LocalControllerBuilder;
 use rust_qsim::simulation::controller::ExternalServices;
 use rust_qsim::simulation::logging::init_std_out_logging_thread_local;
 use rust_qsim::simulation::scenario::GlobalScenario;
+use std::sync::{Arc, Barrier};
 
 #[derive(Parser, Debug, Clone)]
 #[command(author, version, about, long_about = None)]
@@ -20,11 +21,17 @@ struct RoutingCommandLineArgs {
 fn main() {
     let _guard = init_std_out_logging_thread_local();
     let args = RoutingCommandLineArgs::parse();
-    let config = Config::from(args.delegate);
+    let config = Arc::new(Config::from(args.delegate));
 
-    let (router_handle, send, send_sd) =
-        RoutingServiceAdapterFactory::new(vec![&args.router_ip], config.clone())
-            .spawn_thread("router");
+    // Creating the routing adapter is only one task, so we add 1 and not the number of worker threads!
+    let total_thread_count = config.partitioning().num_parts + 1;
+    let barrier = Arc::new(Barrier::new(total_thread_count as usize));
+
+    let factory = RoutingServiceAdapterFactory::new(vec![&args.router_ip], config.clone());
+
+    let executor = AsyncExecutor::from_config(&config, barrier.clone());
+
+    let (router_handle, send, send_sd) = executor.spawn_thread("router", factory);
 
     let mut services = ExternalServices::default();
     services.insert(ExternalServiceType::Routing("pt".into()), send.into());
@@ -34,6 +41,7 @@ fn main() {
     let controller = LocalControllerBuilder::default()
         .global_scenario(scenario)
         .external_services(services)
+        .global_barrier(barrier)
         .build()
         .unwrap();
 

--- a/rust_qsim/src/external_services/routing/routing.proto
+++ b/rust_qsim/src/external_services/routing/routing.proto
@@ -2,9 +2,11 @@ syntax = "proto3";
 package routing;
 
 import "simulation/io/proto/types/population.proto";
+import "google/protobuf/empty.proto";
 
 service RoutingService {
   rpc GetRoute (Request) returns (Response);
+  rpc Shutdown (google.protobuf.Empty) returns (google.protobuf.Empty);
 }
 
 message Request {

--- a/rust_qsim/src/simulation/config.rs
+++ b/rust_qsim/src/simulation/config.rs
@@ -333,8 +333,12 @@ pub struct Output {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Routing {
     pub mode: RoutingMode,
-    #[serde(default)]
+    #[serde(default = "default_to_one")]
     pub threads: usize,
+}
+
+fn default_to_one() -> usize {
+    1
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]

--- a/rust_qsim/src/simulation/controller/local_controller.rs
+++ b/rust_qsim/src/simulation/controller/local_controller.rs
@@ -1,46 +1,68 @@
 use crate::simulation::config::{CommandLineArgs, Config};
-use crate::simulation::controller;
 use crate::simulation::controller::{ExternalServices, PartitionArgumentsBuilder};
 use crate::simulation::logging::init_std_out_logging_thread_local;
 use crate::simulation::messaging::events::EventsSubscriber;
 use crate::simulation::messaging::sim_communication::local_communicator::ChannelSimCommunicator;
 use crate::simulation::scenario::{GlobalScenario, ScenarioPartitionBuilder};
+use crate::simulation::{controller, io};
 use clap::Parser;
 use derive_builder::Builder;
 use nohash_hasher::IntMap;
 use std::collections::HashMap;
-use std::thread;
+use std::sync::{Arc, Barrier};
 use std::thread::JoinHandle;
+use std::{fs, thread};
 use tracing::info;
 
 #[derive(Debug, Builder)]
-#[builder(pattern = "owned")]
+#[builder(pattern = "owned", build_fn(skip))]
 pub struct LocalController {
     global_scenario: GlobalScenario,
     #[builder(default)]
     events_subscriber_per_partition: HashMap<u32, Vec<Box<dyn EventsSubscriber + Send>>>,
     #[builder(default)]
     external_services: ExternalServices,
+    global_barrier: Arc<Barrier>,
+}
+
+impl LocalControllerBuilder {
+    // Implementing a custom build function in order to set the barrier if not set by the user.
+    pub fn build(self) -> Result<LocalController, String> {
+        let global_scenario = self.global_scenario.ok_or("global_scenario is required")?;
+
+        // create a barrier for the number of partitions, if not provided
+        let barrier = self.global_barrier.clone().unwrap_or_else(|| {
+            Arc::new(Barrier::new(
+                global_scenario.config.partitioning().num_parts as usize,
+            ))
+        });
+
+        Ok(LocalController {
+            global_scenario,
+            events_subscriber_per_partition: self
+                .events_subscriber_per_partition
+                .unwrap_or_default(),
+            external_services: self.external_services.clone().unwrap_or_default(),
+            global_barrier: barrier,
+        })
+    }
 }
 
 impl LocalController {
     pub fn run(self) -> IntMap<u32, JoinHandle<()>> {
-        let handles = Self::run_channel(
-            self.global_scenario,
-            self.events_subscriber_per_partition,
-            self.external_services,
-        );
-        handles
+        Self::run_channel(self)
     }
 
-    fn run_channel(
-        global_scenario: GlobalScenario,
-        mut events_subscriber_per_partition: HashMap<u32, Vec<Box<dyn EventsSubscriber + Send>>>,
-        external_services: ExternalServices,
-    ) -> IntMap<u32, JoinHandle<()>> {
-        let num_parts = global_scenario.config.partitioning().num_parts;
+    fn run_channel(mut self) -> IntMap<u32, JoinHandle<()>> {
+        let output_path = io::resolve_path(
+            self.global_scenario.config.context(),
+            &self.global_scenario.config.output().output_dir,
+        );
+        fs::create_dir_all(&output_path).expect("Failed to create output path");
+
+        let num_parts = self.global_scenario.config.partitioning().num_parts;
         let mut partitions: Vec<Option<ScenarioPartitionBuilder>> =
-            ScenarioPartitionBuilder::from(global_scenario)
+            ScenarioPartitionBuilder::from(self.global_scenario)
                 .into_iter()
                 .map(Some)
                 .collect();
@@ -62,10 +84,11 @@ impl LocalController {
 
                 let args = PartitionArgumentsBuilder::default()
                     .communicator(comm)
+                    .global_barrier(self.global_barrier.clone())
                     .scenario_partition(partition)
-                    .external_services(external_services.clone())
+                    .external_services(self.external_services.clone())
                     .events_subscriber(
-                        events_subscriber_per_partition
+                        self.events_subscriber_per_partition
                             .remove(&rank)
                             .unwrap_or_default(),
                     )
@@ -74,7 +97,7 @@ impl LocalController {
                 (
                     rank,
                     thread::Builder::new()
-                        .name(rank.to_string())
+                        .name(format!("qsim-{}", rank))
                         .spawn(move || controller::execute_partition(args))
                         .unwrap(),
                 )
@@ -92,7 +115,7 @@ pub fn run_channel_from_args() {
     info!("Started with args: {:?}", args);
 
     // Load and adapt config
-    let config = Config::from(args);
+    let config = Arc::new(Config::from(args));
 
     // Load and adapt scenario
     let scenario = GlobalScenario::build(config);

--- a/rust_qsim/src/simulation/controller/mod.rs
+++ b/rust_qsim/src/simulation/controller/mod.rs
@@ -15,10 +15,9 @@ use std::any::Any;
 use std::cell::{RefCell, RefMut};
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
 use std::thread::{sleep, JoinHandle};
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
@@ -123,12 +122,12 @@ pub struct PartitionArguments<C: SimCommunicator> {
     external_services: ExternalServices,
     #[builder(default)]
     events_subscriber: Vec<Box<dyn EventsSubscriber + Send>>,
+    global_barrier: Arc<Barrier>,
 }
 
-pub fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArguments<C>) {
+fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArguments<C>) {
     let config = &partition_arguments.scenario_partition.config;
-
-    let _guards = logging::init_logging(&config, partition_arguments.communicator.rank());
+    let _guards = logging::init_logging(config, partition_arguments.communicator.rank());
 
     let comm = partition_arguments.communicator;
     let external_services = partition_arguments.external_services;
@@ -137,20 +136,12 @@ pub fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArgum
     let rank = comm.rank();
     let size = config.partitioning().num_parts;
 
-    let output_path = io::resolve_path(config.context(), &config.output().output_dir);
-    fs::create_dir_all(&output_path).expect("Failed to create output path");
-
-    info!("Process #{rank} of {size} has started. Waiting for other processes to arrive at initial barrier. ");
-    comm.barrier();
-
     let scenario = partition_arguments.scenario_partition.build();
 
-    let events = create_events(&scenario.config, rank, &output_path, subscribers);
-
-    let rc_comm = Rc::new(comm);
+    let events = create_events(&scenario.config, rank, subscribers);
 
     let net_message_broker = NetMessageBroker::new(
-        Rc::clone(&rc_comm),
+        Rc::new(comm),
         &scenario.network,
         &scenario.network_partition,
         scenario.config.computational_setup().global_sync,
@@ -168,7 +159,8 @@ pub fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArgum
     // Wait for all processes to arrive at this barrier. This is important to ensure that the
     // instrumentation of the simulation.run() method does not include any time it takes to
     // load the network and population.
-    rc_comm.barrier();
+    info!("Process #{rank} of {size} has arrived at initial barrier. Waiting for other processes and potentially external services to arrive at global barrier.");
+    partition_arguments.global_barrier.wait();
     simulation.run();
 
     // Drop guards here to make sure that the logging is flushed before we exit.
@@ -180,9 +172,10 @@ pub fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArgum
 fn create_events(
     config: &Config,
     rank: u32,
-    output_path: &Path,
     additional_subscribers: Vec<Box<dyn EventsSubscriber + Send>>,
 ) -> Rc<RefCell<EventsPublisher>> {
+    let output_path = io::resolve_path(config.context(), &config.output().output_dir);
+
     let events = Rc::new(RefCell::new(EventsPublisher::new()));
 
     if config.output().write_events == WriteEvents::Proto {

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -518,8 +518,6 @@ impl SimNetworkPartition {
 
 #[cfg(test)]
 mod tests {
-    use assert_approx_eq::assert_approx_eq;
-
     use super::{SimNetworkPartition, SimNetworkPartitionBuilder};
     use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::id::Id;
@@ -527,6 +525,8 @@ mod tests {
     use crate::simulation::network::{Link, Network, Node};
     use crate::simulation::vehicles::InternalVehicle;
     use crate::test_utils;
+    use assert_approx_eq::assert_approx_eq;
+    use macros::integration_test;
 
     #[test]
     fn from_network() {
@@ -754,7 +754,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[integration_test]
     fn move_nodes_transition_logic() {
         let mut net = Network::new();
         let node1 = Node {
@@ -863,7 +863,7 @@ mod tests {
         assert_approx_eq!(link1 * 2., link2, 100.);
     }
 
-    #[test]
+    #[integration_test]
     fn storage_cap_over_boundaries() {
         // use programmed network here, to avoid instabilities with metis algorithm for small
         // network graphs
@@ -905,7 +905,7 @@ mod tests {
         assert_approx_eq!(100., storage_cap.released, 0.00001);
     }
 
-    #[test]
+    #[integration_test]
     fn neighbors() {
         let mut net = Network::new();
         let node = Node::new(Id::create("node-1"), -0., 0., 0, 1);

--- a/rust_qsim/src/simulation/scenario.rs
+++ b/rust_qsim/src/simulation/scenario.rs
@@ -5,6 +5,7 @@ use crate::simulation::network::Network;
 use crate::simulation::population::Population;
 use crate::simulation::vehicles::garage::Garage;
 use crate::simulation::{id, io};
+use std::sync::Arc;
 use tracing::info;
 
 /// The GlobalScenario contains the full scenario data.
@@ -13,11 +14,12 @@ pub struct GlobalScenario {
     pub network: Network,
     pub garage: Garage,
     pub population: Population,
-    pub config: Config,
+    // this is deliberately an Arc, as it is shared between all partitions and other threads. Otherwise, cloning would be needed.
+    pub config: Arc<Config>,
 }
 
 impl GlobalScenario {
-    pub fn build(config: Config) -> Self {
+    pub fn build(config: Arc<Config>) -> Self {
         id::load_from_file(&io::resolve_path(
             config.context(),
             &config.proto_files().ids,
@@ -73,7 +75,7 @@ pub struct ScenarioPartition {
     pub(crate) garage: Garage,
     pub(crate) population: Population,
     pub(crate) network_partition: SimNetworkPartition,
-    pub(crate) config: Config,
+    pub(crate) config: Arc<Config>,
 }
 
 /// This struct is needed as intermediate step to build a ScenarioPartition.
@@ -83,7 +85,7 @@ pub struct ScenarioPartitionBuilder {
     garage: Garage,
     population: Population,
     network_partition: SimNetworkPartitionBuilder,
-    pub(crate) config: Config,
+    pub(crate) config: Arc<Config>,
 }
 
 impl ScenarioPartitionBuilder {

--- a/rust_qsim/tests/test_3_links.rs
+++ b/rust_qsim/tests/test_3_links.rs
@@ -1,11 +1,12 @@
 use crate::test_simulation::TestExecutorBuilder;
 use macros::integration_test;
-use rust_qsim::simulation::config::CommandLineArgs;
+use rust_qsim::simulation::config::{CommandLineArgs, Config};
 use rust_qsim::simulation::id::store_to_file;
 use rust_qsim::simulation::network::Network;
 use rust_qsim::simulation::population::Population;
 use rust_qsim::simulation::vehicles::garage::Garage;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 mod test_simulation;
 
@@ -30,7 +31,7 @@ fn execute_3_links_single_part() {
         CommandLineArgs::new_with_path("./tests/resources/3-links/3-links-config-1.yml");
 
     TestExecutorBuilder::default()
-        .config_args(config_args)
+        .config(Arc::new(Config::from(config_args)))
         .expected_events(Some("./tests/resources/3-links/expected_events.xml"))
         .build()
         .unwrap()
@@ -47,7 +48,7 @@ fn execute_3_links_2_parts() {
         CommandLineArgs::new_with_path("./tests/resources/3-links/3-links-config-2.yml");
 
     TestExecutorBuilder::default()
-        .config_args(config_args)
+        .config(Arc::new(Config::from(config_args)))
         .expected_events(Some("./tests/resources/3-links/expected_events.xml"))
         .build()
         .unwrap()

--- a/rust_qsim/tests/test_equil.rs
+++ b/rust_qsim/tests/test_equil.rs
@@ -172,7 +172,7 @@ struct MockRoutingAdapter {
 }
 
 impl RequestAdapter<InternalRoutingRequest> for MockRoutingAdapter {
-    async fn on_request(&mut self, req: InternalRoutingRequest) {
+    fn on_request(&mut self, req: InternalRoutingRequest) {
         self.requests.push(req.payload);
         req.response_tx
             .send(InternalRoutingResponse::default())

--- a/rust_qsim/tests/test_equil_teleport.rs
+++ b/rust_qsim/tests/test_equil_teleport.rs
@@ -2,12 +2,13 @@ mod test_simulation;
 
 use crate::test_simulation::TestExecutorBuilder;
 use macros::integration_test;
-use rust_qsim::simulation::config::CommandLineArgs;
+use rust_qsim::simulation::config::{CommandLineArgs, Config};
 use rust_qsim::simulation::id::store_to_file;
 use rust_qsim::simulation::network::Network;
 use rust_qsim::simulation::population::Population;
 use rust_qsim::simulation::vehicles::garage::Garage;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 fn create_resources(out_dir: &PathBuf, population: &str) {
     let input_dir = PathBuf::from("./assets/equil/");
@@ -33,7 +34,7 @@ fn teleport_network_route() {
     );
 
     TestExecutorBuilder::default()
-        .config_args(config_args)
+        .config(Arc::new(Config::from(config_args)))
         .expected_events(Some(
             "./tests/resources/equil/expected_events_teleport_network_route.xml",
         ))
@@ -53,7 +54,7 @@ fn teleport_generic_route() {
     );
 
     TestExecutorBuilder::default()
-        .config_args(config_args)
+        .config(Arc::new(Config::from(config_args)))
         .expected_events(Some(
             "./tests/resources/equil/expected_events_teleport_generic_route.xml",
         ))
@@ -73,7 +74,7 @@ fn simulate_network_route() {
     );
 
     TestExecutorBuilder::default()
-        .config_args(config_args)
+        .config(Arc::new(Config::from(config_args)))
         .expected_events(Some(
             "./tests/resources/equil/expected_events_simulate_network_route.xml",
         ))
@@ -94,7 +95,7 @@ fn simulate_generic_route_panics() {
     );
 
     TestExecutorBuilder::default()
-        .config_args(config_args)
+        .config(Arc::new(Config::from(config_args)))
         .expected_events(None)
         .build()
         .unwrap()

--- a/rust_qsim/tests/test_pt.rs
+++ b/rust_qsim/tests/test_pt.rs
@@ -61,7 +61,7 @@ fn test_pt_adaptive() {
         .push((String::from("routing.mode"), String::from("ad-hoc")));
 
     let (handle, send, shutdown) = RoutingServiceAdapterFactory::new(
-        "http://localhost:50051",
+        vec!["http://localhost:50051"],
         Config::from(config_args.clone()),
     )
     .spawn_thread("routing_adapter");


### PR DESCRIPTION
Add support for multiple routing services with different IP adresses. Also, sync on start and send shutdown command. Sharpened the trait definitions for running service adapters.