### PR TITLE
Add partition events

### DIFF
--- a/rust_qsim/src/simulation/controller/controller.rs
+++ b/rust_qsim/src/simulation/controller/controller.rs
@@ -7,7 +7,7 @@ use crate::simulation::controller::{
 use crate::simulation::events::EventHandlerRegisterFn;
 use crate::simulation::framework_events::{
     ControllerEvent, ControllerEventsManager, ControllerListenerRegisterFn,
-    MobsimListenerRegisterFn,
+    MobsimListenerRegisterFn, PartitionListenerRegisterFn,
 };
 use crate::simulation::messaging::sim_communication::local_communicator::ChannelSimCommunicator;
 use crate::simulation::population::agent_source::{
@@ -41,6 +41,8 @@ pub struct Controller {
     event_handler_per_partition: HashMap<u32, Vec<Box<EventHandlerRegisterFn>>>,
     #[debug(skip)]
     mobsim_event_listener_per_partition: HashMap<u32, Vec<Box<MobsimListenerRegisterFn>>>,
+    #[debug(skip)]
+    partition_event_listener_per_partition: HashMap<u32, Vec<Box<PartitionListenerRegisterFn>>>,
     external_services: ExternalServices,
     global_barrier: Arc<Barrier>,
     adapter_handles: Vec<AdapterHandle>,
@@ -52,6 +54,7 @@ pub struct ControllerBuilder {
     controller_event_register_fn: Vec<Box<ControllerListenerRegisterFn>>,
     event_handler_register_fn: HashMap<u32, Vec<Box<EventHandlerRegisterFn>>>,
     mobsim_event_register_fn: HashMap<u32, Vec<Box<MobsimListenerRegisterFn>>>,
+    partition_event_register_fn: HashMap<u32, Vec<Box<PartitionListenerRegisterFn>>>,
     external_services: ExternalServices,
     global_barrier: Option<Arc<Barrier>>,
     adapter_handles: Vec<AdapterHandle>,
@@ -65,6 +68,7 @@ impl ControllerBuilder {
             controller_event_register_fn: Vec::new(),
             event_handler_register_fn: HashMap::new(),
             mobsim_event_register_fn: HashMap::new(),
+            partition_event_register_fn: HashMap::new(),
             external_services: ExternalServices::default(),
             global_barrier: None,
             adapter_handles: Vec::new(),
@@ -94,6 +98,7 @@ impl ControllerBuilder {
             controller_events_manager: controller_event_manager,
             event_handler_per_partition: self.event_handler_register_fn,
             mobsim_event_listener_per_partition: self.mobsim_event_register_fn,
+            partition_event_listener_per_partition: self.partition_event_register_fn,
             external_services: self.external_services,
             global_barrier: barrier,
             adapter_handles: self.adapter_handles,
@@ -121,6 +126,14 @@ impl ControllerBuilder {
         v: HashMap<u32, Vec<Box<MobsimListenerRegisterFn>>>,
     ) -> Self {
         self.mobsim_event_register_fn = v;
+        self
+    }
+
+    pub fn partition_event_register_fn(
+        mut self,
+        v: HashMap<u32, Vec<Box<PartitionListenerRegisterFn>>>,
+    ) -> Self {
+        self.partition_event_register_fn = v;
         self
     }
 
@@ -246,6 +259,11 @@ impl Controller {
                     )
                     .mobsim_event_listener(
                         self.mobsim_event_listener_per_partition
+                            .remove(&rank)
+                            .unwrap_or_default(),
+                    )
+                    .partition_event_listener(
+                        self.partition_event_listener_per_partition
                             .remove(&rank)
                             .unwrap_or_default(),
                     )

--- a/rust_qsim/src/simulation/controller/mod.rs
+++ b/rust_qsim/src/simulation/controller/mod.rs
@@ -4,7 +4,10 @@ pub mod controller;
 use crate::external_services::{AdapterHandle, ExternalServiceType, RequestToAdapter};
 use crate::simulation::config::{Config, WriteEvents};
 use crate::simulation::events::{EventHandlerRegisterFn, EventsManager};
-use crate::simulation::framework_events::{MobsimEventsManager, MobsimListenerRegisterFn};
+use crate::simulation::framework_events::{
+    MobsimEventsManager, MobsimListenerRegisterFn, PartitionEventsManager,
+    PartitionListenerRegisterFn,
+};
 use crate::simulation::io::proto::proto_events::ProtoEventsWriter;
 use crate::simulation::io::proto::xml_events::XmlEventsWriter;
 use crate::simulation::messaging::sim_communication::SimCommunicator;
@@ -88,16 +91,18 @@ pub struct ThreadLocalComputationalEnvironment {
     // The value is of type Rc as this is a thread-local events manager.
     #[builder(default)]
     events_manager: Rc<RefCell<EventsManager>>,
-    #[builder(default)]
     mobsim_events_manager: Rc<RefCell<MobsimEventsManager>>,
+    partition_events_manager: Rc<RefCell<PartitionEventsManager>>,
 }
 
+#[cfg(test)]
 impl Default for ThreadLocalComputationalEnvironment {
     fn default() -> Self {
         ThreadLocalComputationalEnvironment {
             services: ExternalServices::default(),
             events_manager: Rc::new(RefCell::new(EventsManager::new())),
             mobsim_events_manager: Rc::new(RefCell::new(MobsimEventsManager::default())),
+            partition_events_manager: Rc::new(RefCell::new(PartitionEventsManager::default())),
         }
     }
 }
@@ -125,6 +130,14 @@ impl ThreadLocalComputationalEnvironment {
     pub fn mobsim_event_bus(&self) -> Rc<RefCell<MobsimEventsManager>> {
         self.mobsim_events_manager.clone()
     }
+
+    pub fn partition_events_manager_borrow_mut(&mut self) -> RefMut<'_, PartitionEventsManager> {
+        self.partition_events_manager.borrow_mut()
+    }
+
+    pub fn partition_event_bus(&self) -> Rc<RefCell<PartitionEventsManager>> {
+        self.partition_events_manager.clone()
+    }
 }
 
 #[derive(Debug, Builder)]
@@ -142,6 +155,9 @@ pub struct PartitionArguments<C: SimCommunicator> {
     #[builder(default)]
     #[debug(skip)]
     mobsim_event_listener: Vec<Box<MobsimListenerRegisterFn>>,
+    #[builder(default)]
+    #[debug(skip)]
+    partition_event_listener: Vec<Box<PartitionListenerRegisterFn>>,
     global_barrier: Arc<Barrier>,
 }
 
@@ -155,6 +171,7 @@ fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArguments
     let external_services = partition_arguments.external_services;
     let subscribers = partition_arguments.event_handler;
     let mobsim_subscribers = partition_arguments.mobsim_event_listener;
+    let partition_subscribers = partition_arguments.partition_event_listener;
 
     let rank = comm.rank();
     let size = config.partitioning().num_parts;
@@ -174,12 +191,22 @@ fn execute_partition<C: SimCommunicator>(partition_arguments: PartitionArguments
         .mobsim_events_manager(Rc::new(RefCell::new(MobsimEventsManager::for_partition(
             rank, 0,
         ))))
+        .partition_events_manager(Rc::new(RefCell::new(
+            PartitionEventsManager::for_partition(rank, 0),
+        )))
         .build()
         .unwrap();
 
     {
         let mut bus = comp_env.mobsim_events_manager_borrow_mut();
         for subscriber in mobsim_subscribers {
+            subscriber(&mut bus);
+        }
+    }
+
+    {
+        let mut bus = comp_env.partition_events_manager_borrow_mut();
+        for subscriber in partition_subscribers {
             subscriber(&mut bus);
         }
     }

--- a/rust_qsim/src/simulation/engines/activity_engine.rs
+++ b/rust_qsim/src/simulation/engines/activity_engine.rs
@@ -332,6 +332,8 @@ mod tests {
 
         let env = ThreadLocalComputationalEnvironmentBuilder::default()
             .services(map.into())
+            .mobsim_events_manager(Default::default())
+            .partition_events_manager(Default::default())
             .build()
             .unwrap();
 

--- a/rust_qsim/src/simulation/engines/leg_engine.rs
+++ b/rust_qsim/src/simulation/engines/leg_engine.rs
@@ -96,7 +96,7 @@ impl<C: SimCommunicator> LegEngine<C> {
                 .apply_storage_cap_updates(msg.take_storage_capacities());
 
             for veh in msg.take_vehicles() {
-                self.emit_partition_enter_events(&veh, from);
+                self.emit_partition_enter_events(now, &veh, from);
                 self.pass_vehicle_to_engine(now, veh, false);
             }
         }
@@ -213,13 +213,14 @@ impl<C: SimCommunicator> LegEngine<C> {
         &self.network_engine.network
     }
 
-    fn emit_partition_enter_events(&mut self, vehicle: &SimulationVehicle, from: u32) {
+    fn emit_partition_enter_events(&mut self, now: u32, vehicle: &SimulationVehicle, from: u32) {
         self.comp_env
             .partition_events_manager_borrow_mut()
             .process_event(PartitionEvent::VehicleEntersPartition(
                 VehicleEntersPartitionEvent {
                     vehicle_id: vehicle.id().clone(),
                     from,
+                    time: now,
                 },
             ));
         self.comp_env
@@ -228,6 +229,7 @@ impl<C: SimCommunicator> LegEngine<C> {
                 AgentEntersPartitionEvent {
                     agent_id: vehicle.driver().id().clone(),
                     from,
+                    time: now,
                 },
             ));
         for passenger in vehicle.passengers() {
@@ -237,6 +239,7 @@ impl<C: SimCommunicator> LegEngine<C> {
                     AgentEntersPartitionEvent {
                         agent_id: passenger.id().clone(),
                         from,
+                        time: now,
                     },
                 ));
         }

--- a/rust_qsim/src/simulation/engines/leg_engine.rs
+++ b/rust_qsim/src/simulation/engines/leg_engine.rs
@@ -227,6 +227,15 @@ impl<C: SimCommunicator> LegEngine<C> {
                     agent_id: vehicle.driver().id().clone(),
                 },
             ));
+        for passenger in vehicle.passengers() {
+            self.comp_env
+                .partition_events_manager_borrow_mut()
+                .process_event(PartitionEvent::AgentEntersPartition(
+                    AgentEntersPartitionEvent {
+                        agent_id: passenger.id().clone(),
+                    },
+                ));
+        }
     }
 }
 

--- a/rust_qsim/src/simulation/engines/leg_engine.rs
+++ b/rust_qsim/src/simulation/engines/leg_engine.rs
@@ -90,12 +90,13 @@ impl<C: SimCommunicator> LegEngine<C> {
         let sync_messages = self.send_recv(now);
 
         for mut msg in sync_messages {
+            let from = msg.from_process();
             self.network_engine
                 .network
                 .apply_storage_cap_updates(msg.take_storage_capacities());
 
             for veh in msg.take_vehicles() {
-                self.emit_partition_enter_events(&veh);
+                self.emit_partition_enter_events(&veh, from);
                 self.pass_vehicle_to_engine(now, veh, false);
             }
         }
@@ -212,12 +213,13 @@ impl<C: SimCommunicator> LegEngine<C> {
         &self.network_engine.network
     }
 
-    fn emit_partition_enter_events(&mut self, vehicle: &SimulationVehicle) {
+    fn emit_partition_enter_events(&mut self, vehicle: &SimulationVehicle, from: u32) {
         self.comp_env
             .partition_events_manager_borrow_mut()
             .process_event(PartitionEvent::VehicleEntersPartition(
                 VehicleEntersPartitionEvent {
                     vehicle_id: vehicle.id().clone(),
+                    from,
                 },
             ));
         self.comp_env
@@ -225,6 +227,7 @@ impl<C: SimCommunicator> LegEngine<C> {
             .process_event(PartitionEvent::AgentEntersPartition(
                 AgentEntersPartitionEvent {
                     agent_id: vehicle.driver().id().clone(),
+                    from,
                 },
             ));
         for passenger in vehicle.passengers() {
@@ -233,6 +236,7 @@ impl<C: SimCommunicator> LegEngine<C> {
                 .process_event(PartitionEvent::AgentEntersPartition(
                     AgentEntersPartitionEvent {
                         agent_id: passenger.id().clone(),
+                        from,
                     },
                 ));
         }

--- a/rust_qsim/src/simulation/engines/leg_engine.rs
+++ b/rust_qsim/src/simulation/engines/leg_engine.rs
@@ -8,6 +8,9 @@ use crate::simulation::events::{
     PersonArrivalEventBuilder, PersonDepartureEventBuilder, PersonEntersVehicleEventBuilder,
     PersonLeavesVehicleEventBuilder,
 };
+use crate::simulation::framework_events::{
+    AgentEntersPartitionEvent, PartitionEvent, VehicleEntersPartitionEvent,
+};
 use crate::simulation::id::Id;
 use crate::simulation::messaging::messages::InternalSyncMessage;
 use crate::simulation::messaging::sim_communication::SimCommunicator;
@@ -92,6 +95,7 @@ impl<C: SimCommunicator> LegEngine<C> {
                 .apply_storage_cap_updates(msg.take_storage_capacities());
 
             for veh in msg.take_vehicles() {
+                self.emit_partition_enter_events(&veh);
                 self.pass_vehicle_to_engine(now, veh, false);
             }
         }
@@ -206,6 +210,23 @@ impl<C: SimCommunicator> LegEngine<C> {
 
     pub fn network(&self) -> &SimNetworkPartition {
         &self.network_engine.network
+    }
+
+    fn emit_partition_enter_events(&mut self, vehicle: &SimulationVehicle) {
+        self.comp_env
+            .partition_events_manager_borrow_mut()
+            .process_event(PartitionEvent::VehicleEntersPartition(
+                VehicleEntersPartitionEvent {
+                    vehicle_id: vehicle.id().clone(),
+                },
+            ));
+        self.comp_env
+            .partition_events_manager_borrow_mut()
+            .process_event(PartitionEvent::AgentEntersPartition(
+                AgentEntersPartitionEvent {
+                    agent_id: vehicle.driver().id().clone(),
+                },
+            ));
     }
 }
 

--- a/rust_qsim/src/simulation/engines/mod.rs
+++ b/rust_qsim/src/simulation/engines/mod.rs
@@ -1,4 +1,34 @@
+use crate::simulation::controller::ThreadLocalComputationalEnvironment;
+use crate::simulation::framework_events::{
+    AgentLeavesPartitionEvent, PartitionEvent, VehicleLeavesPartitionEvent,
+};
+use crate::simulation::time_queue::Identifiable;
+use crate::simulation::vehicles::SimulationVehicle;
+
 pub mod activity_engine;
 pub mod leg_engine;
 pub mod network_engine;
 pub mod teleportation_engine;
+
+fn emit_partition_leave_events(
+    comp_env: &mut ThreadLocalComputationalEnvironment,
+    vehicle: &SimulationVehicle,
+    to: u32,
+) {
+    comp_env
+        .partition_events_manager_borrow_mut()
+        .process_event(PartitionEvent::VehicleLeavesPartition(
+            VehicleLeavesPartitionEvent {
+                vehicle_id: vehicle.id().clone(),
+                to,
+            },
+        ));
+    comp_env
+        .partition_events_manager_borrow_mut()
+        .process_event(PartitionEvent::AgentLeavesPartition(
+            AgentLeavesPartitionEvent {
+                agent_id: vehicle.driver().id().clone(),
+                to,
+            },
+        ));
+}

--- a/rust_qsim/src/simulation/engines/mod.rs
+++ b/rust_qsim/src/simulation/engines/mod.rs
@@ -31,4 +31,14 @@ fn emit_partition_leave_events(
                 to,
             },
         ));
+    for passenger in vehicle.passengers() {
+        comp_env
+            .partition_events_manager_borrow_mut()
+            .process_event(PartitionEvent::AgentLeavesPartition(
+                AgentLeavesPartitionEvent {
+                    agent_id: passenger.id().clone(),
+                    to,
+                },
+            ));
+    }
 }

--- a/rust_qsim/src/simulation/engines/mod.rs
+++ b/rust_qsim/src/simulation/engines/mod.rs
@@ -14,6 +14,7 @@ fn emit_partition_leave_events(
     comp_env: &mut ThreadLocalComputationalEnvironment,
     vehicle: &SimulationVehicle,
     to: u32,
+    now: u32,
 ) {
     comp_env
         .partition_events_manager_borrow_mut()
@@ -21,6 +22,7 @@ fn emit_partition_leave_events(
             VehicleLeavesPartitionEvent {
                 vehicle_id: vehicle.id().clone(),
                 to,
+                time: now,
             },
         ));
     comp_env
@@ -29,6 +31,7 @@ fn emit_partition_leave_events(
             AgentLeavesPartitionEvent {
                 agent_id: vehicle.driver().id().clone(),
                 to,
+                time: now,
             },
         ));
     for passenger in vehicle.passengers() {
@@ -38,6 +41,7 @@ fn emit_partition_leave_events(
                 AgentLeavesPartitionEvent {
                     agent_id: passenger.id().clone(),
                     to,
+                    time: now,
                 },
             ));
     }

--- a/rust_qsim/src/simulation/engines/network_engine.rs
+++ b/rust_qsim/src/simulation/engines/network_engine.rs
@@ -1,12 +1,8 @@
 use crate::simulation::controller::ThreadLocalComputationalEnvironment;
 use crate::simulation::engines::emit_partition_leave_events;
-use crate::simulation::framework_events::{
-    AgentLeavesPartitionEvent, PartitionEvent, VehicleLeavesPartitionEvent,
-};
 use crate::simulation::messaging::sim_communication::SimCommunicator;
 use crate::simulation::messaging::sim_communication::message_broker::NetMessageBroker;
 use crate::simulation::network::sim_network::SimNetworkPartition;
-use crate::simulation::time_queue::Identifiable;
 use crate::simulation::vehicles::SimulationVehicle;
 use tracing::instrument;
 

--- a/rust_qsim/src/simulation/engines/network_engine.rs
+++ b/rust_qsim/src/simulation/engines/network_engine.rs
@@ -49,7 +49,7 @@ impl NetworkEngine {
                 veh.curr_link_id()
                     .expect("Vehicles leaving a partition must have a destination link"),
             );
-            emit_partition_leave_events(&mut self.comp_env, &veh, to);
+            emit_partition_leave_events(&mut self.comp_env, &veh, to, now);
             net_message_broker.add_veh(veh, now);
         }
 

--- a/rust_qsim/src/simulation/engines/network_engine.rs
+++ b/rust_qsim/src/simulation/engines/network_engine.rs
@@ -1,7 +1,12 @@
 use crate::simulation::controller::ThreadLocalComputationalEnvironment;
+use crate::simulation::engines::emit_partition_leave_events;
+use crate::simulation::framework_events::{
+    AgentLeavesPartitionEvent, PartitionEvent, VehicleLeavesPartitionEvent,
+};
 use crate::simulation::messaging::sim_communication::SimCommunicator;
 use crate::simulation::messaging::sim_communication::message_broker::NetMessageBroker;
 use crate::simulation::network::sim_network::SimNetworkPartition;
+use crate::simulation::time_queue::Identifiable;
 use crate::simulation::vehicles::SimulationVehicle;
 use tracing::instrument;
 
@@ -44,6 +49,11 @@ impl NetworkEngine {
         let move_links_result = self.network.move_links(&mut self.comp_env, now);
 
         for veh in move_links_result.vehicles_exit_partition {
+            let to = net_message_broker.rank_for_link(
+                veh.curr_link_id()
+                    .expect("Vehicles leaving a partition must have a destination link"),
+            );
+            emit_partition_leave_events(&mut self.comp_env, &veh, to);
             net_message_broker.add_veh(veh, now);
         }
 

--- a/rust_qsim/src/simulation/engines/teleportation_engine.rs
+++ b/rust_qsim/src/simulation/engines/teleportation_engine.rs
@@ -43,7 +43,7 @@ impl TeleportationEngine {
                     .curr_link_id()
                     .expect("Remote teleported vehicles must have a destination link"),
             );
-            emit_partition_leave_events(&mut self.comp_env, &vehicle, to);
+            emit_partition_leave_events(&mut self.comp_env, &vehicle, to, now);
             net_message_broker.add_veh(vehicle, now);
         }
     }

--- a/rust_qsim/src/simulation/engines/teleportation_engine.rs
+++ b/rust_qsim/src/simulation/engines/teleportation_engine.rs
@@ -1,6 +1,7 @@
 use crate::simulation::agents::agent::SimulationAgent;
 use crate::simulation::agents::{AgentEvent, EnvironmentalEventObserver, SimulationAgentLogic};
 use crate::simulation::controller::ThreadLocalComputationalEnvironment;
+use crate::simulation::engines::emit_partition_leave_events;
 use crate::simulation::events::{
     PtTeleportationArrivalEventBuilder, TeleportationArrivalEventBuilder,
 };
@@ -37,6 +38,12 @@ impl TeleportationEngine {
         if Simulation::is_local_route(&vehicle, net_message_broker) {
             self.queue.add(vehicle, now);
         } else {
+            let to = net_message_broker.rank_for_link(
+                vehicle
+                    .curr_link_id()
+                    .expect("Remote teleported vehicles must have a destination link"),
+            );
+            emit_partition_leave_events(&mut self.comp_env, &vehicle, to);
             net_message_broker.add_veh(vehicle, now);
         }
     }

--- a/rust_qsim/src/simulation/framework_events/mod.rs
+++ b/rust_qsim/src/simulation/framework_events/mod.rs
@@ -1,4 +1,38 @@
+use crate::simulation::id::Id;
+use crate::simulation::scenario::population::InternalPerson;
+use crate::simulation::scenario::vehicles::InternalVehicle;
+
 pub type QSimId = u32;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PartitionEvent {
+    AgentEntersPartition(AgentEntersPartitionEvent),
+    AgentLeavesPartition(AgentLeavesPartitionEvent),
+    VehicleEntersPartition(VehicleEntersPartitionEvent),
+    VehicleLeavesPartition(VehicleLeavesPartitionEvent),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentEntersPartitionEvent {
+    pub agent_id: Id<InternalPerson>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct AgentLeavesPartitionEvent {
+    pub agent_id: Id<InternalPerson>,
+    pub to: QSimId,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VehicleEntersPartitionEvent {
+    pub vehicle_id: Id<InternalVehicle>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VehicleLeavesPartitionEvent {
+    pub vehicle_id: Id<InternalVehicle>,
+    pub to: QSimId,
+}
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MobsimEvent {
@@ -101,12 +135,15 @@ pub struct EventMeta {
 
 pub type MobsimRuntimeEvent = RuntimeEvent<MobsimEvent>;
 pub type ControllerRuntimeEvent = RuntimeEvent<ControllerEvent>;
+pub type PartitionRuntimeEvent = RuntimeEvent<PartitionEvent>;
 
 pub type MobsimEventsManager = FrameworkEventsManager<MobsimEvent>;
 pub type ControllerEventsManager = FrameworkEventsManager<ControllerEvent>;
+pub type PartitionEventsManager = FrameworkEventsManager<PartitionEvent>;
 
 pub type MobsimListenerRegisterFn = dyn FnOnce(&mut MobsimEventsManager) + Send;
 pub type ControllerListenerRegisterFn = dyn FnOnce(&mut ControllerEventsManager) + Send;
+pub type PartitionListenerRegisterFn = dyn FnOnce(&mut PartitionEventsManager) + Send;
 
 #[derive(Debug, Clone, Copy)]
 struct EventRuntimeState {
@@ -211,7 +248,21 @@ impl FrameworkEventsManager<MobsimEvent> {
     }
 }
 
+#[cfg(test)]
 impl Default for FrameworkEventsManager<MobsimEvent> {
+    fn default() -> Self {
+        Self::for_partition(0, 0)
+    }
+}
+
+impl FrameworkEventsManager<PartitionEvent> {
+    pub fn for_partition(qsim_id: QSimId, iteration: u32) -> Self {
+        Self::new(EventOrigin::Partition(qsim_id), iteration)
+    }
+}
+
+#[cfg(test)]
+impl Default for FrameworkEventsManager<PartitionEvent> {
     fn default() -> Self {
         Self::for_partition(0, 0)
     }
@@ -374,6 +425,106 @@ mod tests {
         });
 
         manager.process_event(MobsimEvent::before_sim_step(10));
+
+        assert_eq!(vec!["high", "default", "low"], order.borrow().clone());
+    }
+
+    #[test]
+    fn partition_events_use_partition_origin_and_invoke_callbacks() {
+        let mut manager = PartitionEventsManager::for_partition(4, 6);
+        let received: Rc<RefCell<Vec<PartitionRuntimeEvent>>> = Rc::new(RefCell::new(Vec::new()));
+        let received_clone = received.clone();
+
+        manager.on_event(move |event| {
+            received_clone.borrow_mut().push(event.clone());
+        });
+
+        manager.process_event(PartitionEvent::VehicleLeavesPartition(
+            VehicleLeavesPartitionEvent {
+                vehicle_id: Id::create("veh-1"),
+                to: 9,
+            },
+        ));
+        manager.process_event(PartitionEvent::AgentEntersPartition(
+            AgentEntersPartitionEvent {
+                agent_id: Id::create("agent-1"),
+            },
+        ));
+
+        let events = received.borrow();
+        assert_eq!(2, events.len());
+
+        assert_eq!(EventOrigin::Partition(4), events[0].meta.origin);
+        assert_eq!(6, events[0].meta.iteration);
+        assert_eq!(0, events[0].meta.seq_no);
+        assert_eq!(
+            PartitionEvent::VehicleLeavesPartition(VehicleLeavesPartitionEvent {
+                vehicle_id: Id::create("veh-1"),
+                to: 9,
+            }),
+            events[0].payload.clone()
+        );
+
+        assert_eq!(EventOrigin::Partition(4), events[1].meta.origin);
+        assert_eq!(6, events[1].meta.iteration);
+        assert_eq!(1, events[1].meta.seq_no);
+        assert_eq!(
+            PartitionEvent::AgentEntersPartition(AgentEntersPartitionEvent {
+                agent_id: Id::create("agent-1"),
+            }),
+            events[1].payload.clone()
+        );
+    }
+
+    #[test]
+    fn partition_next_iteration_resets_seq_counter() {
+        let mut manager = PartitionEventsManager::for_partition(3, 8);
+
+        let first = manager.process_event(PartitionEvent::VehicleEntersPartition(
+            VehicleEntersPartitionEvent {
+                vehicle_id: Id::create("veh-2"),
+            },
+        ));
+        assert_eq!(8, first.meta.iteration);
+        assert_eq!(0, first.meta.seq_no);
+
+        manager.next_iteration();
+
+        let second = manager.process_event(PartitionEvent::AgentLeavesPartition(
+            AgentLeavesPartitionEvent {
+                agent_id: Id::create("agent-2"),
+                to: 7,
+            },
+        ));
+        assert_eq!(9, second.meta.iteration);
+        assert_eq!(0, second.meta.seq_no);
+    }
+
+    #[test]
+    fn partition_callbacks_are_called_by_descending_priority() {
+        let mut manager = PartitionEventsManager::for_partition(5, 0);
+        let order: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+
+        let order_default = order.clone();
+        manager.on_event(move |_| {
+            order_default.borrow_mut().push("default");
+        });
+
+        let order_high = order.clone();
+        manager.on_event_with_priority(7, move |_| {
+            order_high.borrow_mut().push("high");
+        });
+
+        let order_low = order.clone();
+        manager.on_event_with_priority(-2, move |_| {
+            order_low.borrow_mut().push("low");
+        });
+
+        manager.process_event(PartitionEvent::VehicleEntersPartition(
+            VehicleEntersPartitionEvent {
+                vehicle_id: Id::create("veh-3"),
+            },
+        ));
 
         assert_eq!(vec!["high", "default", "low"], order.borrow().clone());
     }

--- a/rust_qsim/src/simulation/framework_events/mod.rs
+++ b/rust_qsim/src/simulation/framework_events/mod.rs
@@ -16,24 +16,28 @@ pub enum PartitionEvent {
 pub struct AgentEntersPartitionEvent {
     pub agent_id: Id<InternalPerson>,
     pub from: QSimId,
+    pub time: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AgentLeavesPartitionEvent {
     pub agent_id: Id<InternalPerson>,
     pub to: QSimId,
+    pub time: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VehicleEntersPartitionEvent {
     pub vehicle_id: Id<InternalVehicle>,
     pub from: QSimId,
+    pub time: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VehicleLeavesPartitionEvent {
     pub vehicle_id: Id<InternalVehicle>,
     pub to: QSimId,
+    pub time: u32,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -445,12 +449,14 @@ mod tests {
             VehicleLeavesPartitionEvent {
                 vehicle_id: Id::create("veh-1"),
                 to: 9,
+                time: 42,
             },
         ));
         manager.process_event(PartitionEvent::AgentEntersPartition(
             AgentEntersPartitionEvent {
                 agent_id: Id::create("agent-1"),
                 from: 2,
+                time: 43,
             },
         ));
 
@@ -464,6 +470,7 @@ mod tests {
             PartitionEvent::VehicleLeavesPartition(VehicleLeavesPartitionEvent {
                 vehicle_id: Id::create("veh-1"),
                 to: 9,
+                time: 42,
             }),
             events[0].payload.clone()
         );
@@ -475,6 +482,7 @@ mod tests {
             PartitionEvent::AgentEntersPartition(AgentEntersPartitionEvent {
                 agent_id: Id::create("agent-1"),
                 from: 2,
+                time: 43,
             }),
             events[1].payload.clone()
         );
@@ -488,6 +496,7 @@ mod tests {
             VehicleEntersPartitionEvent {
                 vehicle_id: Id::create("veh-2"),
                 from: 6,
+                time: 10,
             },
         ));
         assert_eq!(8, first.meta.iteration);
@@ -499,6 +508,7 @@ mod tests {
             AgentLeavesPartitionEvent {
                 agent_id: Id::create("agent-2"),
                 to: 7,
+                time: 20,
             },
         ));
         assert_eq!(9, second.meta.iteration);
@@ -529,6 +539,7 @@ mod tests {
             VehicleEntersPartitionEvent {
                 vehicle_id: Id::create("veh-3"),
                 from: 1,
+                time: 5,
             },
         ));
 

--- a/rust_qsim/src/simulation/framework_events/mod.rs
+++ b/rust_qsim/src/simulation/framework_events/mod.rs
@@ -15,6 +15,7 @@ pub enum PartitionEvent {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AgentEntersPartitionEvent {
     pub agent_id: Id<InternalPerson>,
+    pub from: QSimId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -26,6 +27,7 @@ pub struct AgentLeavesPartitionEvent {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VehicleEntersPartitionEvent {
     pub vehicle_id: Id<InternalVehicle>,
+    pub from: QSimId,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -448,6 +450,7 @@ mod tests {
         manager.process_event(PartitionEvent::AgentEntersPartition(
             AgentEntersPartitionEvent {
                 agent_id: Id::create("agent-1"),
+                from: 2,
             },
         ));
 
@@ -471,6 +474,7 @@ mod tests {
         assert_eq!(
             PartitionEvent::AgentEntersPartition(AgentEntersPartitionEvent {
                 agent_id: Id::create("agent-1"),
+                from: 2,
             }),
             events[1].payload.clone()
         );
@@ -483,6 +487,7 @@ mod tests {
         let first = manager.process_event(PartitionEvent::VehicleEntersPartition(
             VehicleEntersPartitionEvent {
                 vehicle_id: Id::create("veh-2"),
+                from: 6,
             },
         ));
         assert_eq!(8, first.meta.iteration);
@@ -523,6 +528,7 @@ mod tests {
         manager.process_event(PartitionEvent::VehicleEntersPartition(
             VehicleEntersPartitionEvent {
                 vehicle_id: Id::create("veh-3"),
+                from: 1,
             },
         ));
 


### PR DESCRIPTION
There is a new event bus 🚀 partition events hold information about agents and vehicles crossing the partition boundaries.