### PR TITLE
Make vehicles defined in routes actually be read

### DIFF
--- a/rust_qsim/assets/equil/equil-1-plan.xml
+++ b/rust_qsim/assets/equil/equil-1-plan.xml
@@ -22,7 +22,7 @@
                     <attribute name="routingMode" class="java.lang.String">car</attribute>
                 </attributes>
                 <route type="links" start_link="1" end_link="20" trav_time="undefined" distance="25000.0"
-                       vehicleRefId="1">1 6 15 20
+                       vehicleRefId="1_car">1 6 15 20
                 </route>
             </leg>
             <activity type="w" link="20" x="3456.0" y="4242.0" max_dur="00:10:00">
@@ -32,7 +32,7 @@
                     <attribute name="routingMode" class="java.lang.String">car</attribute>
                 </attributes>
                 <route type="links" start_link="20" end_link="20" trav_time="undefined" distance="0.0"
-                       vehicleRefId="1">20
+                       vehicleRefId="1_car">20
                 </route>
             </leg>
             <activity type="w" link="20" x="10000.0" y="0.0" max_dur="03:30:00">
@@ -42,7 +42,7 @@
                     <attribute name="routingMode" class="java.lang.String">car</attribute>
                 </attributes>
                 <route type="links" start_link="20" end_link="1" trav_time="undefined" distance="65000.0"
-                       vehicleRefId="1">20 21 22 23 1
+                       vehicleRefId="1_car">20 21 22 23 1
                 </route>
             </leg>
             <activity type="h" link="1" x="-25000.0" y="0.0">

--- a/rust_qsim/src/simulation/engines/leg_engine.rs
+++ b/rust_qsim/src/simulation/engines/leg_engine.rs
@@ -289,16 +289,15 @@ impl VehicularDepartureHandler {
                 .unwrap(),
         );
 
-        let veh_id = route
+        let veh_id = if let Some(v) = route
             .as_generic()
             .vehicle()
-            .as_ref()
-            .unwrap_or(&Id::get_from_ext(&format!(
-                "{}_{}",
-                agent.id().external(),
-                leg.mode.external()
-            )))
-            .clone();
+            .as_ref() {v.clone()} else {
+                Id::get_from_ext(&format!(
+                                            "{}_{}",
+                                            agent.id().external(),
+                                            leg.mode.external()))
+            };
 
         if self.main_modes.contains(&leg.mode) {
             assert!(

--- a/rust_qsim/src/simulation/engines/leg_engine.rs
+++ b/rust_qsim/src/simulation/engines/leg_engine.rs
@@ -289,15 +289,15 @@ impl VehicularDepartureHandler {
                 .unwrap(),
         );
 
-        let veh_id = if let Some(v) = route
-            .as_generic()
-            .vehicle()
-            .as_ref() {v.clone()} else {
-                Id::get_from_ext(&format!(
-                                            "{}_{}",
-                                            agent.id().external(),
-                                            leg.mode.external()))
-            };
+        let veh_id = if let Some(v) = route.as_generic().vehicle().as_ref() {
+            v.clone()
+        } else {
+            Id::get_from_ext(&format!(
+                "{}_{}",
+                agent.id().external(),
+                leg.mode.external()
+            ))
+        };
 
         if self.main_modes.contains(&leg.mode) {
             assert!(

--- a/rust_qsim/src/simulation/scenario/population.rs
+++ b/rust_qsim/src/simulation/scenario/population.rs
@@ -378,10 +378,9 @@ impl InternalRoute {
     }
 
     fn from_io(io: IORoute, id: Id<InternalPerson>, mode: Id<String>) -> Self {
-        let external = if let Some(v) = io.vehicle {
-            v
-        } else {
-            format!("{}_{}", id.external(), mode.external())
+        let external = match io.vehicle {
+            Some(v) if v != "null" && !v.is_empty() => v,
+            _ => format!("{}_{}", id.external(), mode.external()),
         };
         let generic = InternalGenericRoute::new(
             Id::create(io.start_link.expect("Route must have start link").as_str()),

--- a/rust_qsim/src/simulation/scenario/population.rs
+++ b/rust_qsim/src/simulation/scenario/population.rs
@@ -378,7 +378,7 @@ impl InternalRoute {
     }
 
     fn from_io(io: IORoute, id: Id<InternalPerson>, mode: Id<String>) -> Self {
-        let external = format!("{}_{}", id.external(), mode.external());
+        let external = if let Some(v) = io.vehicle {v} else { format!("{}_{}", id.external(), mode.external())};
         let generic = InternalGenericRoute::new(
             Id::create(io.start_link.expect("Route must have start link").as_str()),
             Id::create(io.end_link.expect("Route must have end link").as_str()),

--- a/rust_qsim/src/simulation/scenario/population.rs
+++ b/rust_qsim/src/simulation/scenario/population.rs
@@ -378,7 +378,11 @@ impl InternalRoute {
     }
 
     fn from_io(io: IORoute, id: Id<InternalPerson>, mode: Id<String>) -> Self {
-        let external = if let Some(v) = io.vehicle {v} else { format!("{}_{}", id.external(), mode.external())};
+        let external = if let Some(v) = io.vehicle {
+            v
+        } else {
+            format!("{}_{}", id.external(), mode.external())
+        };
         let generic = InternalGenericRoute::new(
             Id::create(io.start_link.expect("Route must have start link").as_str()),
             Id::create(io.end_link.expect("Route must have end link").as_str()),


### PR DESCRIPTION
- as noted in issue #269, vehicles defined in routes in XML population files are so far ignored, and routes are always assigned vehicles with id `<personId>_<mode>`. This can lead to problems if such vehicles are not defined in the vehicle file, since they will then be missing in the garage. This PR changes this, i.e., the default vehicle id is used only if no vehicle is defined in a route.
- in the leg engine in `handle_departure`, so far, `unwrap_or` was used when reading vehicle ids from a given route. This can cause panics unnecessarily, since `unwrap_or` is eagerly evaluated, and the fallback value relies on `Id::get_from_ext`, which panics if the id doesn't exist. This PR changes the logic to lazily evaluated `if let`. 
    - This avoids unnecessary panics if the route has an assigned vehicle (no reason to panic just because the default vehicle id doesn't exist, if the default vehicle is not needed)
    - However the code can technically still panic, if the route has no vehicle _and_ the default vehicle id doesn't exist
        - Note that when reading from XML this cannot happen, since all `InternalRoute`s then get a vehicle, since a default one is generated when converting `IORoute`s to `InternalRoute`s if the former has no vehicle.