### PR TITLE
Add read_xml_events function

### DIFF
--- a/rust_qsim/src/bin/merge_proto2xml_events.rs
+++ b/rust_qsim/src/bin/merge_proto2xml_events.rs
@@ -35,7 +35,7 @@ fn main() {
     read_proto_events(
         &mut manager,
         &PathBuf::from(args.path),
-        String::from("events"),
+        "events",
         args.num_parts,
     );
     info!(

--- a/rust_qsim/src/bin/merge_proto2xml_events.rs
+++ b/rust_qsim/src/bin/merge_proto2xml_events.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use rust_qsim::simulation::events::EventsManager;
-use rust_qsim::simulation::events::utils::read_proto_events;
+use rust_qsim::simulation::events::utils::read_partitioned_events;
 use rust_qsim::simulation::id;
 use rust_qsim::simulation::io::xml::events::XmlEventsWriter;
 use rust_qsim::simulation::logging::init_std_out_logging_thread_local;
@@ -32,12 +32,14 @@ fn main() {
 
     register_proto_writer(&mut manager);
 
-    read_proto_events(
+    read_partitioned_events(
         &mut manager,
         &PathBuf::from(args.path),
         "events",
         args.num_parts,
-    );
+        "binpb",
+    )
+    .expect("Failed to read events from file");
     info!(
         "Finished writing to xml file ({}).",
         output_file_path.display()

--- a/rust_qsim/src/bin/merge_proto_events.rs
+++ b/rust_qsim/src/bin/merge_proto_events.rs
@@ -35,7 +35,7 @@ fn main() {
     read_proto_events(
         &mut manager,
         &PathBuf::from(args.path),
-        String::from("events"),
+        "events",
         args.num_parts,
     );
     info!(

--- a/rust_qsim/src/bin/merge_proto_events.rs
+++ b/rust_qsim/src/bin/merge_proto_events.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
 use rust_qsim::simulation::events::EventsManager;
-use rust_qsim::simulation::events::utils::read_proto_events;
+use rust_qsim::simulation::events::utils::read_partitioned_events;
 use rust_qsim::simulation::id;
 use rust_qsim::simulation::io::proto::proto_events::ProtoEventsWriter;
 use rust_qsim::simulation::logging::init_std_out_logging_thread_local;
@@ -32,12 +32,14 @@ fn main() {
 
     register_proto_writer(&mut manager);
 
-    read_proto_events(
+    read_partitioned_events(
         &mut manager,
         &PathBuf::from(args.path),
         "events",
         args.num_parts,
-    );
+        "binpb",
+    )
+    .expect("Failed to read events from file");
     info!(
         "Finished writing to proto file ({}).",
         output_file_path.display()

--- a/rust_qsim/src/bin/proto2xml.rs
+++ b/rust_qsim/src/bin/proto2xml.rs
@@ -17,7 +17,8 @@ fn main() {
 
     let output_file_path = PathBuf::from(&args.path).join("events.xml.gz");
 
-    utils::convert_proto_to_xml_events(args.path, args.num_parts, output_file_path);
+    utils::convert_proto_to_xml_events(args.path, args.num_parts, output_file_path)
+        .expect("Failed to convert proto events to xml");
 }
 
 #[derive(Parser, Debug)]

--- a/rust_qsim/src/simulation/events/utils.rs
+++ b/rust_qsim/src/simulation/events/utils.rs
@@ -1,6 +1,6 @@
 use crate::generated::events::GenericEvent;
 use crate::simulation::events::comparison::EventBatch;
-use crate::simulation::events::{EventTrait, EventsManager, GenericEventBuilder, comparison};
+use crate::simulation::events::{EventTrait, EventsManager, comparison};
 use crate::simulation::io::proto::proto_events::{ProtoEventsReader, process_events};
 use crate::simulation::io::xml::events::{XmlEventsReader, XmlEventsWriter};
 use crate::simulation::logging::init_std_out_logging_thread_local;
@@ -31,7 +31,6 @@ impl<R: Read + Seek> StatefulReader<R> {
 
 struct StatefulXmlReader {
     reader: XmlEventsReader,
-    curr_time_step: SimTime,
     next_event: Option<(SimTime, Box<dyn EventTrait>)>,
 }
 
@@ -107,11 +106,7 @@ pub fn read_xml_events(
             continue;
         };
 
-        let wrapper = StatefulXmlReader {
-            reader,
-            curr_time_step: SimTime::default(),
-            next_event,
-        };
+        let wrapper = StatefulXmlReader { reader, next_event };
         readers.push(wrapper);
     }
 

--- a/rust_qsim/src/simulation/events/utils.rs
+++ b/rust_qsim/src/simulation/events/utils.rs
@@ -79,20 +79,24 @@ pub fn read_proto_events(
     events.finish();
 }
 
-/// Reads all XML event files from the given folder and publishes them to the given events manager.
-/// Supports both `.xml` and `.xml.gz` files.
+/// Reads all XML event files with name `{folder}/{prefix}.{i}.xml` for `0 <= i < num_parts`, or
+/// `[...].xml.gz` if `is_gz=true` and publishes them to the given events manager.
 /// Assumes that ids are already loaded.
 pub fn read_xml_events(
     events_mgr: &mut EventsManager,
     folder: impl AsRef<Path>,
     prefix: String,
     num_parts: u32,
+    is_gz: bool,
 ) {
     // initialize readers, one for every file.
     let mut readers = Vec::new();
     info!("Reading from XML Files: ");
     for i in 0..num_parts {
-        let path = PathBuf::from(folder.as_ref()).join(format!("{prefix}.{i}.xml"));
+        let path = PathBuf::from(folder.as_ref()).join(format!(
+            "{prefix}.{i}.xml{}",
+            if is_gz { ".gz" } else { "" } // add .gz ending if specified
+        ));
         info!("\t {}", path.to_str().unwrap());
         let reader = XmlEventsReader::new(&path);
         let wrapper = StatefulXmlReader {
@@ -121,6 +125,7 @@ pub fn read_xml_events(
                     info!("Reading time step: {:?}h", hour);
                     last_reported_time_step = hour;
                 }
+                // process the event
                 events_mgr.process_event(event.as_ref());
                 reader.curr_time_step = time;
             }
@@ -298,6 +303,7 @@ mod test {
             &PathBuf::from(&resource_folder),
             String::from("expected_events"),
             num_parts,
+            false,
         );
 
         // assert that the event strings that the events handler handled are all the events inside

--- a/rust_qsim/src/simulation/events/utils.rs
+++ b/rust_qsim/src/simulation/events/utils.rs
@@ -1,6 +1,6 @@
 use crate::generated::events::GenericEvent;
 use crate::simulation::events::comparison::EventBatch;
-use crate::simulation::events::{EventsManager, comparison};
+use crate::simulation::events::{EventTrait, EventsManager, GenericEventBuilder, comparison};
 use crate::simulation::io::proto::proto_events::{ProtoEventsReader, process_events};
 use crate::simulation::io::xml::events::{XmlEventsReader, XmlEventsWriter};
 use crate::simulation::logging::init_std_out_logging_thread_local;
@@ -32,21 +32,22 @@ impl<R: Read + Seek> StatefulReader<R> {
 struct StatefulXmlReader {
     reader: XmlEventsReader,
     curr_time_step: SimTime,
+    next_event: Option<(SimTime, Box<dyn EventTrait>)>,
 }
 
 /// Reads all proto events from the given folder and publishes them to the given events manager.
 /// Assumes that ids are already loaded.
 pub fn read_proto_events(
     events: &mut EventsManager,
-    folder: &Path,
-    prefix: String,
+    folder: impl AsRef<Path>,
+    prefix: &str,
     num_parts: u32,
 ) {
     let mut readers = Vec::new();
     info!("Reading from Files: ");
     for i in 0..num_parts {
-        let path = PathBuf::from(&folder).join(format!("{prefix}.{i}.binpb"));
-        info!("\t {}", path.to_str().unwrap());
+        let path = PathBuf::from(&folder.as_ref()).join(format!("{prefix}.{i}.binpb"));
+        info!("\t {}", path.display());
         let reader = ProtoEventsReader::from_file(&path);
         let wrapper = StatefulReader {
             reader,
@@ -85,7 +86,7 @@ pub fn read_proto_events(
 pub fn read_xml_events(
     events_mgr: &mut EventsManager,
     folder: impl AsRef<Path>,
-    prefix: String,
+    prefix: &str,
     num_parts: u32,
     is_gz: bool,
 ) {
@@ -97,11 +98,19 @@ pub fn read_xml_events(
             "{prefix}.{i}.xml{}",
             if is_gz { ".gz" } else { "" } // add .gz ending if specified
         ));
-        info!("\t {}", path.to_str().unwrap());
-        let reader = XmlEventsReader::new(&path);
+        info!("\t {}", path.display());
+        let mut reader = XmlEventsReader::new(&path);
+
+        let next_event = reader.read_next();
+        if next_event.is_none() {
+            // if first event is empty, don't add the reader of this file to the readers vec
+            continue;
+        };
+
         let wrapper = StatefulXmlReader {
             reader,
             curr_time_step: SimTime::default(),
+            next_event,
         };
         readers.push(wrapper);
     }
@@ -109,15 +118,30 @@ pub fn read_xml_events(
     info!("Starting to read XML event files.");
     let mut last_reported_time_step = 0;
     while !readers.is_empty() {
-        readers.sort_by(|a, b| a.curr_time_step.cmp(&b.curr_time_step));
+        // sort readers by next event time, if None use default 0.0
+        readers.sort_by(|a, b| {
+            a.next_event
+                .as_ref()
+                .map(|e| e.0)
+                .unwrap_or(SimTime::default())
+                .cmp(
+                    &b.next_event
+                        .as_ref()
+                        .map(|e| e.0)
+                        .unwrap_or(SimTime::default()),
+                )
+        });
 
         // get the reader with the smallest curr time step and process its event
         let reader = readers.first_mut().unwrap();
 
-        match reader.reader.read_next() {
+        match reader.next_event.as_ref() {
+            //reader.reader.read_next() {
+            // if the reader is empty, remove it from the vec of readers
             None => {
                 readers.remove(0);
             }
+            // if the reader has an event, process it and update the reader's next event
             Some((time, event)) => {
                 let secs = time.as_secs();
                 let hour = secs / 3600;
@@ -127,7 +151,8 @@ pub fn read_xml_events(
                 }
                 // process the event
                 events_mgr.process_event(event.as_ref());
-                reader.curr_time_step = time;
+                // reader.curr_time_step = time;
+                reader.next_event = reader.reader.read_next();
             }
         }
     }
@@ -152,7 +177,7 @@ pub fn convert_proto_to_xml_events(
     read_proto_events(
         &mut manager,
         path_to_proto_files.as_ref(),
-        String::from("events"),
+        "events",
         num_parts,
     );
     info!(
@@ -273,15 +298,16 @@ mod test {
         }
     }
 
-    /// test the read_from_xml function to check that the events read from an XML file are correctly
-    /// published to the events manager.
-    /// Writes the corresponding xml string of all published events into a vector (using the above
-    /// defined EventsToVecCollector event handler), and then comparing the vector with the expected
-    /// event strings (corresponding to the events in the read XML file).
+    /// test the `read_from_xml` function to check that the events read from two XML files are
+    /// correctly published to the events manager, in the right order.
+    /// Writes the corresponding XML string of all published events into a vector (using the above
+    /// defined `EventsToVecCollector` event handler), and then comparing the vector with the
+    /// expected event strings (corresponding to the events in the read XML files).
     #[test]
     fn test_read_from_xml() {
+        let _guard = init_std_out_logging_thread_local();
         let resource_folder = "./tests/resources/events/".to_string();
-        let num_parts = 1;
+        let num_parts = 2;
 
         let mut events_mgr = EventsManager::new();
 
@@ -301,19 +327,19 @@ mod test {
         read_xml_events(
             &mut events_mgr,
             &PathBuf::from(&resource_folder),
-            String::from("expected_events"),
+            "expected_events",
             num_parts,
             false,
         );
 
         // assert that the event strings that the events handler handled are all the events inside
-        // the read "expected_events.0.xml"
-        // (the vector corresponds to the events in tests/resources/events/expected_events.0.xml)
+        // the read files "expected_events.0.xml" and "expected_events.1.xml", in correct order.
         assert_eq!(
             event_string_collection.lock().unwrap().clone(),
             vec![
                 "<event time=\"32400\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"10\" actType=\"home\"/>\n",
                 "<event time=\"32400.5\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32406\" type=\"travelled\" person=\"100\" distance=\"10\" mode=\"walk\"/>\n", // this row comes from the file expected_events.1.xml
                 "<event time=\"32408\" type=\"travelled\" person=\"100\" distance=\"10\" mode=\"walk\"/>\n",
                 "<event time=\"32408\" type=\"arrival\" person=\"100\" link=\"link1\" legMode=\"walk\"/>\n",
                 "<event time=\"32409\" type=\"actstart\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",

--- a/rust_qsim/src/simulation/events/utils.rs
+++ b/rust_qsim/src/simulation/events/utils.rs
@@ -1,10 +1,13 @@
 use crate::generated::events::GenericEvent;
 use crate::simulation::events::comparison::EventBatch;
-use crate::simulation::events::{EventTrait, EventsManager, comparison};
+use crate::simulation::events::{EventTrait, EventsManager, GenericEventBuilder, comparison};
 use crate::simulation::io::proto::proto_events::{ProtoEventsReader, process_events};
 use crate::simulation::io::xml::events::{XmlEventsReader, XmlEventsWriter};
 use crate::simulation::logging::init_std_out_logging_thread_local;
 use crate::simulation::time::SimTime;
+use std::error::Error;
+use std::fmt::Display;
+use std::fs::File;
 use std::io::{Read, Seek};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::AtomicBool;
@@ -12,147 +15,222 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::{fmt, thread};
 use tracing::info;
 
-struct StatefulReader<R: Read + Seek> {
-    reader: ProtoEventsReader<R>,
-    curr_time_step: (SimTime, Vec<GenericEvent>),
+/// An event file reader with a state, containing the time and event data of the next time step.
+/// This is needed so that multiple readers can be sorted by the time of their next event.
+trait StatefulReader {
+    /// preload the event time and event data of the next timestep into the reader state. Returns
+    /// `Some(())` if the next time step was successfully preloaded, or `None` if there are no more
+    /// events to read.
+    fn load_next(&mut self) -> Option<()>;
+    /// process the events that are currently preloaded in the state using the given event manager
+    fn process_preloaded_events(&self, manager: &mut EventsManager);
+    /// read the time of the preloaded events
+    fn get_preloaded_time(&self) -> SimTime;
 }
 
-impl<R: Read + Seek> StatefulReader<R> {
-    pub fn load_next(&mut self) -> Option<()> {
+struct StatefulProtoReader<R: Read + Seek> {
+    reader: ProtoEventsReader<R>,
+    preloaded_time_step: (SimTime, Vec<GenericEvent>),
+}
+
+impl StatefulProtoReader<File> {
+    fn from_file(path: impl AsRef<Path>) -> Self {
+        Self {
+            reader: ProtoEventsReader::from_file(path.as_ref()),
+            preloaded_time_step: (SimTime::default(), Vec::new()),
+        }
+    }
+}
+
+impl StatefulReader for StatefulProtoReader<File> {
+    fn load_next(&mut self) -> Option<()> {
         match self.reader.next() {
             None => None,
             Some(time_step) => {
-                self.curr_time_step = time_step;
+                self.preloaded_time_step = time_step;
                 Some(())
             }
         }
+    }
+    fn process_preloaded_events(&self, manager: &mut EventsManager) {
+        process_events(
+            self.preloaded_time_step.0,
+            &self.preloaded_time_step.1,
+            manager,
+        )
+    }
+
+    fn get_preloaded_time(&self) -> SimTime {
+        self.preloaded_time_step.0
     }
 }
 
 struct StatefulXmlReader {
     reader: XmlEventsReader,
-    next_event: Option<(SimTime, Box<dyn EventTrait>)>,
+    preloaded_event: (SimTime, Box<dyn EventTrait>),
 }
 
-/// Reads all proto events from the given folder and publishes them to the given events manager.
-/// Assumes that ids are already loaded.
-pub fn read_proto_events(
-    events: &mut EventsManager,
-    folder: impl AsRef<Path>,
-    prefix: &str,
-    num_parts: u32,
-) {
-    let mut readers = Vec::new();
-    info!("Reading from Files: ");
-    for i in 0..num_parts {
-        let path = PathBuf::from(&folder.as_ref()).join(format!("{prefix}.{i}.binpb"));
-        info!("\t {}", path.display());
-        let reader = ProtoEventsReader::from_file(&path);
-        let wrapper = StatefulReader {
-            reader,
-            curr_time_step: (SimTime::default(), Vec::new()),
-        };
-        readers.push(wrapper);
+impl StatefulXmlReader {
+    fn from_file(path: impl AsRef<Path>) -> Self {
+        Self {
+            reader: XmlEventsReader::new(path),
+            preloaded_event: (
+                SimTime::default(),
+                Box::new(
+                    GenericEventBuilder::default()
+                        .time(SimTime::default())
+                        .build()
+                        .unwrap(),
+                ),
+            ),
+        }
+    }
+}
+
+impl StatefulReader for StatefulXmlReader {
+    fn load_next(&mut self) -> Option<()> {
+        match self.reader.read_next() {
+            None => None,
+            Some(next_event) => {
+                self.preloaded_event = next_event;
+                Some(())
+            }
+        }
+    }
+    fn process_preloaded_events(&self, manager: &mut EventsManager) {
+        manager.process_event(self.preloaded_event.1.as_ref());
     }
 
-    info!("Starting to read proto files.");
+    fn get_preloaded_time(&self) -> SimTime {
+        self.preloaded_event.0
+    }
+}
+
+/// Error type for file types that are given to the event reading functions
+#[derive(Debug)]
+pub enum FileTypeError {
+    Unimplemented(String),
+    NotGiven,
+    NotValidUnicode,
+}
+
+impl Display for FileTypeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            FileTypeError::Unimplemented(ext) => write!(f, "unimplemented file type: {}", ext),
+            FileTypeError::NotGiven => write!(f, "file was given without extension"),
+            FileTypeError::NotValidUnicode => write!(f, "file extension is not valid unicode"),
+        }
+    }
+}
+impl Error for FileTypeError {}
+
+/// Reads the events from the given file and publishes them to the given events manager.
+/// When reading a proto file, assumes that ids are already loaded.
+pub fn read_events(
+    events_mgr: &mut EventsManager,
+    path: impl AsRef<Path>,
+) -> Result<(), FileTypeError> {
+    info!("Reading events from file: {}", path.as_ref().display());
+    let file_extension = path
+        .as_ref()
+        .extension()
+        .ok_or_else(|| FileTypeError::NotGiven)?;
+
+    let mut reader: Box<dyn StatefulReader> = match file_extension
+        .to_str()
+        .map(|s| s.to_ascii_lowercase())
+        .as_deref()
+    {
+        Some("xml") | Some("xml.gz") => Box::new(StatefulXmlReader::from_file(path)),
+        Some("binpb") | Some("pbf") => Box::new(StatefulProtoReader::from_file(path)),
+        Some(other) => return Err(FileTypeError::Unimplemented(other.to_string())),
+        None => return Err(FileTypeError::NotValidUnicode),
+    };
+
     let mut last_reported_time_step = 0;
-    while !readers.is_empty() {
-        readers.sort_by(|a, b| a.curr_time_step.0.cmp(&b.curr_time_step.0));
 
-        // get the reader with the smallest curr time step and process its events
-        let reader = readers.first_mut().unwrap();
-
-        let secs = reader.curr_time_step.0.as_secs();
+    // preload next events, and if they exist, process them
+    while reader.load_next().is_some() {
+        let secs = reader.get_preloaded_time().as_secs();
         let hour = secs / 3600;
         if hour > last_reported_time_step && secs.is_multiple_of(3600) {
             info!("Reading time step: {:?}h", hour);
             last_reported_time_step = hour;
         }
 
-        process_events(reader.curr_time_step.0, &reader.curr_time_step.1, events);
-        if reader.load_next().is_none() {
-            readers.remove(0);
-        };
+        // process the preloaded events
+        reader.process_preloaded_events(events_mgr);
     }
-    info!("Finished reading proto files.");
-    events.finish();
+
+    info!("Finished reading file.");
+    events_mgr.finish();
+
+    Ok(())
 }
 
-/// Reads all XML event files with name `{folder}/{prefix}.{i}.xml` for `0 <= i < num_parts`, or
-/// `[...].xml.gz` if `is_gz=true` and publishes them to the given events manager.
-/// Assumes that ids are already loaded.
-pub fn read_xml_events(
+/// Reads all event files from the given folder with file name `{prefix}.{i}.{file_extension}`,
+/// where `i=0..num_parts`, and publishes them to the given events manager.
+/// When reading proto files, assumes that ids are already loaded.
+pub fn read_partitioned_events(
     events_mgr: &mut EventsManager,
     folder: impl AsRef<Path>,
     prefix: &str,
     num_parts: u32,
-    is_gz: bool,
-) {
-    // initialize readers, one for every file.
-    let mut readers = Vec::new();
-    info!("Reading from XML Files: ");
-    for i in 0..num_parts {
-        let path = PathBuf::from(folder.as_ref()).join(format!(
-            "{prefix}.{i}.xml{}",
-            if is_gz { ".gz" } else { "" } // add .gz ending if specified
-        ));
-        info!("\t {}", path.display());
-        let mut reader = XmlEventsReader::new(&path);
+    file_extension: &str,
+) -> Result<(), FileTypeError> {
+    let normalized_extension = file_extension.trim_start_matches('.').to_ascii_lowercase();
 
-        let next_event = reader.read_next();
-        if next_event.is_none() {
-            // if first event is empty, don't add the reader of this file to the readers vec
-            continue;
+    let mut readers: Vec<Box<dyn StatefulReader>> = Vec::new();
+
+    info!("Reading from Files: ");
+
+    for i in 0..num_parts {
+        let path =
+            PathBuf::from(&folder.as_ref()).join(format!("{prefix}.{i}.{normalized_extension}"));
+        info!("\t {}", path.display());
+
+        // create stateful reader based on given file extension, return error if unsupported
+        let mut reader: Box<dyn StatefulReader> = match normalized_extension.as_str() {
+            "binpb" | "pbf" => Box::new(StatefulProtoReader::from_file(path)),
+            "xml" | "xml.gz" => Box::new(StatefulXmlReader::from_file(path)),
+            _ => return Err(FileTypeError::Unimplemented(normalized_extension)),
         };
 
-        let wrapper = StatefulXmlReader { reader, next_event };
-        readers.push(wrapper);
+        // initialize stateful reader by preloading the first state. If this returns None, the file
+        // is empty so we don't add the reader to the readers.
+        if reader.load_next().is_none() {
+            continue;
+        }
+        readers.push(reader);
     }
 
-    info!("Starting to read XML event files.");
+    info!("Starting to read files.");
     let mut last_reported_time_step = 0;
     while !readers.is_empty() {
-        // sort readers by next event time, if None use default 0.0
-        readers.sort_by(|a, b| {
-            a.next_event
-                .as_ref()
-                .map(|e| e.0)
-                .unwrap_or(SimTime::default())
-                .cmp(
-                    &b.next_event
-                        .as_ref()
-                        .map(|e| e.0)
-                        .unwrap_or(SimTime::default()),
-                )
-        });
+        readers.sort_by(|a, b| a.get_preloaded_time().cmp(&b.get_preloaded_time()));
 
-        // get the reader with the smallest curr time step and process its event
+        // get the reader with the smallest curr time step and process its events
         let reader = readers.first_mut().unwrap();
 
-        match reader.next_event.as_ref() {
-            //reader.reader.read_next() {
-            // if the reader is empty, remove it from the vec of readers
-            None => {
-                readers.remove(0);
-            }
-            // if the reader has an event, process it and update the reader's next event
-            Some((time, event)) => {
-                let secs = time.as_secs();
-                let hour = secs / 3600;
-                if hour > last_reported_time_step && secs.is_multiple_of(3600) {
-                    info!("Reading time step: {:?}h", hour);
-                    last_reported_time_step = hour;
-                }
-                // process the event
-                events_mgr.process_event(event.as_ref());
-                // reader.curr_time_step = time;
-                reader.next_event = reader.reader.read_next();
-            }
+        let secs = reader.get_preloaded_time().as_secs();
+        let hour = secs / 3600;
+        if hour > last_reported_time_step && secs.is_multiple_of(3600) {
+            info!("Reading time step: {:?}h", hour);
+            last_reported_time_step = hour;
         }
+
+        // process the events currently stored in "self.curr_time_step"
+        reader.process_preloaded_events(events_mgr);
+
+        if reader.load_next().is_none() {
+            readers.remove(0);
+        };
     }
-    info!("Finished reading XML event files.");
+    info!("Finished reading files.");
     events_mgr.finish();
+
+    Ok(())
 }
 
 /// Reads all proto events from the given folder and writes them to a single XML file (optionally
@@ -162,23 +240,25 @@ pub fn convert_proto_to_xml_events(
     path_to_proto_files: impl AsRef<Path>,
     num_parts: u32,
     output_file_path: impl AsRef<Path> + 'static + Send + Clone,
-) {
+) -> Result<(), FileTypeError> {
     let mut manager = EventsManager::new();
 
     let register_xml_writer = XmlEventsWriter::register_fn(output_file_path.clone());
 
     register_xml_writer(&mut manager);
 
-    read_proto_events(
+    read_partitioned_events(
         &mut manager,
         path_to_proto_files.as_ref(),
         "events",
         num_parts,
-    );
+        "binpb",
+    )?;
     info!(
         "Finished writing to xml file ({}).",
         output_file_path.as_ref().to_str().unwrap()
     );
+    Ok(())
 }
 
 #[derive(Debug, Clone)]
@@ -191,7 +271,7 @@ pub enum EventsFileNotEqualError {
     },
 }
 
-impl fmt::Display for EventsFileNotEqualError {
+impl Display for EventsFileNotEqualError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             EventsFileNotEqualError::DifferentEventTimes => write!(f, "Event times differ."),
@@ -293,13 +373,127 @@ mod test {
         }
     }
 
-    /// test the `read_from_xml` function to check that the events read from two XML files are
-    /// correctly published to the events manager, in the right order.
+    /// test the read_events function on a single xml file. Publishes the read events to an event
+    /// manager where the above `EventsToVecCollector` is registered, and then compares the
+    /// collected event strings with the expected event strings.
+    #[test]
+    fn test_read_single_xml_file() {
+        let _guard = init_std_out_logging_thread_local();
+        let resource_folder = "./tests/resources/events/".to_string();
+        let path = PathBuf::from(resource_folder).join("expected_events.0.xml");
+
+        let mut events_mgr = EventsManager::new();
+
+        // the event strings read from the XML file will be collected in this vector, to be compared
+        // with the expected event strings
+        let event_string_collection = Arc::new(Mutex::new(Vec::new()));
+
+        // XmlEventsVecCollector is an event handler that writes event strings, like those written
+        // into XML, into a given vector.
+        let register_xml_event_collector =
+            EventsToVecCollector::register_fn(event_string_collection.clone());
+
+        register_xml_event_collector(&mut events_mgr);
+
+        // read the XML events and publish them to the events manager, which will trigger the event
+        // handler above and fill the event_string_collection vector
+        read_events(&mut events_mgr, &path).unwrap();
+
+        // assert that the event strings that the events handler handled are all the events inside
+        // the read file "expected_events.0.xml"
+        assert_eq!(
+            event_string_collection.lock().unwrap().clone(),
+            vec![
+                "<event time=\"32400\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"10\" actType=\"home\"/>\n",
+                "<event time=\"32400.5\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32408\" type=\"travelled\" person=\"100\" distance=\"10\" mode=\"walk\"/>\n",
+                "<event time=\"32408\" type=\"arrival\" person=\"100\" link=\"link1\" legMode=\"walk\"/>\n",
+                "<event time=\"32409\" type=\"actstart\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32409\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32409\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"car\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32409\" type=\"PersonEntersVehicle\" person=\"100\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32409.123456789\" type=\"vehicle enters traffic\" person=\"100\" link=\"link1\" vehicle=\"100_car\" networkMode=\"car\" relativePosition=\"1\"/>\n",
+                "<event time=\"32410\" type=\"left link\" link=\"link1\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32410\" type=\"entered link\" link=\"link2\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32511\" type=\"left link\" link=\"link2\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32511\" type=\"entered link\" link=\"link3\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32521\" type=\"vehicle leaves traffic\" person=\"100\" link=\"link3\" vehicle=\"100_car\" networkMode=\"car\" relativePosition=\"1\"/>\n",
+                "<event time=\"32521\" type=\"PersonLeavesVehicle\" person=\"100\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32521\" type=\"arrival\" person=\"100\" link=\"link3\" legMode=\"car\"/>\n",
+                "<event time=\"32522\" type=\"actstart\" person=\"100\" link=\"link3\" x=\"1100\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32522\" type=\"actend\" person=\"100\" link=\"link3\" x=\"1100\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32522\" type=\"departure\" person=\"100\" link=\"link3\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32538\" type=\"travelled\" person=\"100\" distance=\"20\" mode=\"walk\"/>\n",
+                "<event time=\"32538\" type=\"arrival\" person=\"100\" link=\"link3\" legMode=\"walk\"/>\n",
+                "<event time=\"32539\" type=\"actstart\" person=\"100\" link=\"link3\" x=\"1100\" y=\"20\" actType=\"errands\"/>\n"
+            ]
+        );
+    }
+
+    /// test the read_events function on a single proto file. Publishes the read events to an event
+    /// manager where the above `EventsToVecCollector` is registered, and then compares the
+    /// collected event strings with the expected event strings.
+    #[test]
+    fn test_read_single_proto_file() {
+        let _guard = init_std_out_logging_thread_local();
+        let resource_folder = "./tests/resources/events/".to_string();
+        let path = PathBuf::from(resource_folder).join("expected_events.0.xml");
+
+        let mut events_mgr = EventsManager::new();
+
+        // the event strings read from the XML file will be collected in this vector, to be compared
+        // with the expected event strings
+        let event_string_collection = Arc::new(Mutex::new(Vec::new()));
+
+        // XmlEventsVecCollector is an event handler that writes event strings, like those written
+        // into XML, into a given vector.
+        let register_xml_event_collector =
+            EventsToVecCollector::register_fn(event_string_collection.clone());
+
+        register_xml_event_collector(&mut events_mgr);
+
+        // read the XML events and publish them to the events manager, which will trigger the event
+        // handler above and fill the event_string_collection vector
+        read_events(&mut events_mgr, &path).unwrap();
+
+        // assert that the event strings that the events handler handled are all the events inside
+        // the read file "expected_events.0.xml"
+        assert_eq!(
+            event_string_collection.lock().unwrap().clone(),
+            vec![
+                "<event time=\"32400\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"10\" actType=\"home\"/>\n",
+                "<event time=\"32400.5\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32408\" type=\"travelled\" person=\"100\" distance=\"10\" mode=\"walk\"/>\n",
+                "<event time=\"32408\" type=\"arrival\" person=\"100\" link=\"link1\" legMode=\"walk\"/>\n",
+                "<event time=\"32409\" type=\"actstart\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32409\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32409\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"car\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32409\" type=\"PersonEntersVehicle\" person=\"100\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32409.123456789\" type=\"vehicle enters traffic\" person=\"100\" link=\"link1\" vehicle=\"100_car\" networkMode=\"car\" relativePosition=\"1\"/>\n",
+                "<event time=\"32410\" type=\"left link\" link=\"link1\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32410\" type=\"entered link\" link=\"link2\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32511\" type=\"left link\" link=\"link2\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32511\" type=\"entered link\" link=\"link3\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32521\" type=\"vehicle leaves traffic\" person=\"100\" link=\"link3\" vehicle=\"100_car\" networkMode=\"car\" relativePosition=\"1\"/>\n",
+                "<event time=\"32521\" type=\"PersonLeavesVehicle\" person=\"100\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32521\" type=\"arrival\" person=\"100\" link=\"link3\" legMode=\"car\"/>\n",
+                "<event time=\"32522\" type=\"actstart\" person=\"100\" link=\"link3\" x=\"1100\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32522\" type=\"actend\" person=\"100\" link=\"link3\" x=\"1100\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32522\" type=\"departure\" person=\"100\" link=\"link3\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32538\" type=\"travelled\" person=\"100\" distance=\"20\" mode=\"walk\"/>\n",
+                "<event time=\"32538\" type=\"arrival\" person=\"100\" link=\"link3\" legMode=\"walk\"/>\n",
+                "<event time=\"32539\" type=\"actstart\" person=\"100\" link=\"link3\" x=\"1100\" y=\"20\" actType=\"errands\"/>\n"
+            ]
+        );
+    }
+
+    /// test the `read_partitioned_events` function to check that the events read from two XML
+    /// files are correctly published to the events manager, in the right order.
     /// Writes the corresponding XML string of all published events into a vector (using the above
     /// defined `EventsToVecCollector` event handler), and then comparing the vector with the
     /// expected event strings (corresponding to the events in the read XML files).
     #[test]
-    fn test_read_from_xml() {
+    fn test_read_partitioned_xml() {
         let _guard = init_std_out_logging_thread_local();
         let resource_folder = "./tests/resources/events/".to_string();
         let num_parts = 2;
@@ -319,13 +513,14 @@ mod test {
 
         // read the XML events and publish them to the events manager, which will trigger the event
         // handler above and fill the event_string_collection vector
-        read_xml_events(
+        read_partitioned_events(
             &mut events_mgr,
             &PathBuf::from(&resource_folder),
             "expected_events",
             num_parts,
-            false,
-        );
+            "xml",
+        )
+        .unwrap();
 
         // assert that the event strings that the events handler handled are all the events inside
         // the read files "expected_events.0.xml" and "expected_events.1.xml", in correct order.

--- a/rust_qsim/src/simulation/events/utils.rs
+++ b/rust_qsim/src/simulation/events/utils.rs
@@ -19,9 +19,9 @@ use tracing::info;
 /// This is needed so that multiple readers can be sorted by the time of their next event.
 trait StatefulReader {
     /// preload the event time and event data of the next timestep into the reader state. Returns
-    /// `Some(())` if the next time step was successfully preloaded, or `None` if there are no more
+    /// `true` if the next time step was successfully preloaded, or `false` if there are no more
     /// events to read.
-    fn load_next(&mut self) -> Option<()>;
+    fn load_next(&mut self) -> bool;
     /// process the events that are currently preloaded in the state using the given event manager
     fn process_preloaded_events(&self, manager: &mut EventsManager);
     /// read the time of the preloaded events
@@ -43,12 +43,12 @@ impl StatefulProtoReader<File> {
 }
 
 impl StatefulReader for StatefulProtoReader<File> {
-    fn load_next(&mut self) -> Option<()> {
+    fn load_next(&mut self) -> bool {
         match self.reader.next() {
-            None => None,
+            None => false,
             Some(time_step) => {
                 self.preloaded_time_step = time_step;
-                Some(())
+                true
             }
         }
     }
@@ -88,12 +88,12 @@ impl StatefulXmlReader {
 }
 
 impl StatefulReader for StatefulXmlReader {
-    fn load_next(&mut self) -> Option<()> {
+    fn load_next(&mut self) -> bool {
         match self.reader.read_next() {
-            None => None,
+            None => false,
             Some(next_event) => {
                 self.preloaded_event = next_event;
-                Some(())
+                true
             }
         }
     }
@@ -151,7 +151,7 @@ pub fn read_events(
     let mut last_reported_time_step = 0;
 
     // preload next events, and if they exist, process them
-    while reader.load_next().is_some() {
+    while reader.load_next() {
         let secs = reader.get_preloaded_time().as_secs();
         let hour = secs / 3600;
         if hour > last_reported_time_step && secs.is_multiple_of(3600) {
@@ -199,7 +199,7 @@ pub fn read_partitioned_events(
 
         // initialize stateful reader by preloading the first state. If this returns None, the file
         // is empty so we don't add the reader to the readers.
-        if reader.load_next().is_none() {
+        if !reader.load_next() {
             continue;
         }
         readers.push(reader);
@@ -223,7 +223,7 @@ pub fn read_partitioned_events(
         // process the events currently stored in "self.curr_time_step"
         reader.process_preloaded_events(events_mgr);
 
-        if reader.load_next().is_none() {
+        if !reader.load_next() {
             readers.remove(0);
         };
     }

--- a/rust_qsim/src/simulation/events/utils.rs
+++ b/rust_qsim/src/simulation/events/utils.rs
@@ -2,7 +2,7 @@ use crate::generated::events::GenericEvent;
 use crate::simulation::events::comparison::EventBatch;
 use crate::simulation::events::{EventsManager, comparison};
 use crate::simulation::io::proto::proto_events::{ProtoEventsReader, process_events};
-use crate::simulation::io::xml::events::XmlEventsWriter;
+use crate::simulation::io::xml::events::{XmlEventsReader, XmlEventsWriter};
 use crate::simulation::logging::init_std_out_logging_thread_local;
 use crate::simulation::time::SimTime;
 use std::io::{Read, Seek};
@@ -27,6 +27,11 @@ impl<R: Read + Seek> StatefulReader<R> {
             }
         }
     }
+}
+
+struct StatefulXmlReader {
+    reader: XmlEventsReader,
+    curr_time_step: SimTime,
 }
 
 /// Reads all proto events from the given folder and publishes them to the given events manager.
@@ -72,6 +77,57 @@ pub fn read_proto_events(
     }
     info!("Finished reading proto files.");
     events.finish();
+}
+
+/// Reads all XML event files from the given folder and publishes them to the given events manager.
+/// Supports both `.xml` and `.xml.gz` files.
+/// Assumes that ids are already loaded.
+pub fn read_xml_events(
+    events_mgr: &mut EventsManager,
+    folder: impl AsRef<Path>,
+    prefix: String,
+    num_parts: u32,
+) {
+    // initialize readers, one for every file.
+    let mut readers = Vec::new();
+    info!("Reading from XML Files: ");
+    for i in 0..num_parts {
+        let path = PathBuf::from(folder.as_ref()).join(format!("{prefix}.{i}.xml"));
+        info!("\t {}", path.to_str().unwrap());
+        let reader = XmlEventsReader::new(&path);
+        let wrapper = StatefulXmlReader {
+            reader,
+            curr_time_step: SimTime::default(),
+        };
+        readers.push(wrapper);
+    }
+
+    info!("Starting to read XML event files.");
+    let mut last_reported_time_step = 0;
+    while !readers.is_empty() {
+        readers.sort_by(|a, b| a.curr_time_step.cmp(&b.curr_time_step));
+
+        // get the reader with the smallest curr time step and process its event
+        let reader = readers.first_mut().unwrap();
+
+        match reader.reader.read_next() {
+            None => {
+                readers.remove(0);
+            }
+            Some((time, event)) => {
+                let secs = time.as_secs();
+                let hour = secs / 3600;
+                if hour > last_reported_time_step && secs.is_multiple_of(3600) {
+                    info!("Reading time step: {:?}h", hour);
+                    last_reported_time_step = hour;
+                }
+                events_mgr.process_event(event.as_ref());
+                reader.curr_time_step = time;
+            }
+        }
+    }
+    info!("Finished reading XML event files.");
+    events_mgr.finish();
 }
 
 /// Reads all proto events from the given folder and writes them to a single XML file (optionally
@@ -177,4 +233,102 @@ pub fn compare_xml_event_files(
     // Return the comparison result
     let result = comparison_result.lock().unwrap();
     result.clone()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::simulation::events::{EventHandlerRegisterFn, EventTrait};
+    use std::rc::Rc;
+
+    /// event handler that writes any event as a string (corresponding to an entry in an XML file)
+    /// into a given vector
+    struct EventsToVecCollector;
+
+    impl EventsToVecCollector {
+        /// on any event, push the event string into the vector
+        fn on_any(&self, e: &dyn EventTrait, event_string_collection: Arc<Mutex<Vec<String>>>) {
+            event_string_collection
+                .lock()
+                .unwrap()
+                .push(XmlEventsWriter::event_2_string(e));
+        }
+
+        /// register the handler to the manager, telling it to call the above function on any event
+        pub fn register_fn(
+            event_string_collection: Arc<Mutex<Vec<String>>>,
+        ) -> Box<EventHandlerRegisterFn> {
+            Box::new(move |events: &mut EventsManager| {
+                let to_vec_collector = Rc::new(EventsToVecCollector);
+
+                events.on_any(move |e| {
+                    to_vec_collector.on_any(e, event_string_collection.clone());
+                });
+            })
+        }
+    }
+
+    /// test the read_from_xml function to check that the events read from an XML file are correctly
+    /// published to the events manager.
+    /// Writes the corresponding xml string of all published events into a vector (using the above
+    /// defined EventsToVecCollector event handler), and then comparing the vector with the expected
+    /// event strings (corresponding to the events in the read XML file).
+    #[test]
+    fn test_read_from_xml() {
+        let resource_folder = "./tests/resources/events/".to_string();
+        let num_parts = 1;
+
+        let mut events_mgr = EventsManager::new();
+
+        // the event strings read from the XML file will be collected in this vector, to be compared
+        // with the expected event strings
+        let event_string_collection = Arc::new(Mutex::new(Vec::new()));
+
+        // XmlEventsVecCollector is an event handler that writes event strings, like those written
+        // into XML, into a given vector.
+        let register_xml_event_collector =
+            EventsToVecCollector::register_fn(event_string_collection.clone());
+
+        register_xml_event_collector(&mut events_mgr);
+
+        // read the XML events and publish them to the events manager, which will trigger the event
+        // handler above and fill the event_string_collection vector
+        read_xml_events(
+            &mut events_mgr,
+            &PathBuf::from(&resource_folder),
+            String::from("expected_events"),
+            num_parts,
+        );
+
+        // assert that the event strings that the events handler handled are all the events inside
+        // the read "expected_events.0.xml"
+        // (the vector corresponds to the events in tests/resources/events/expected_events.0.xml)
+        assert_eq!(
+            event_string_collection.lock().unwrap().clone(),
+            vec![
+                "<event time=\"32400\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"10\" actType=\"home\"/>\n",
+                "<event time=\"32400.5\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32408\" type=\"travelled\" person=\"100\" distance=\"10\" mode=\"walk\"/>\n",
+                "<event time=\"32408\" type=\"arrival\" person=\"100\" link=\"link1\" legMode=\"walk\"/>\n",
+                "<event time=\"32409\" type=\"actstart\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32409\" type=\"actend\" person=\"100\" link=\"link1\" x=\"5\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32409\" type=\"departure\" person=\"100\" link=\"link1\" legMode=\"car\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32409\" type=\"PersonEntersVehicle\" person=\"100\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32409.123456789\" type=\"vehicle enters traffic\" person=\"100\" link=\"link1\" vehicle=\"100_car\" networkMode=\"car\" relativePosition=\"1\"/>\n",
+                "<event time=\"32410\" type=\"left link\" link=\"link1\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32410\" type=\"entered link\" link=\"link2\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32511\" type=\"left link\" link=\"link2\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32511\" type=\"entered link\" link=\"link3\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32521\" type=\"vehicle leaves traffic\" person=\"100\" link=\"link3\" vehicle=\"100_car\" networkMode=\"car\" relativePosition=\"1\"/>\n",
+                "<event time=\"32521\" type=\"PersonLeavesVehicle\" person=\"100\" vehicle=\"100_car\"/>\n",
+                "<event time=\"32521\" type=\"arrival\" person=\"100\" link=\"link3\" legMode=\"car\"/>\n",
+                "<event time=\"32522\" type=\"actstart\" person=\"100\" link=\"link3\" x=\"1100\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32522\" type=\"actend\" person=\"100\" link=\"link3\" x=\"1100\" y=\"0\" actType=\"car interaction\"/>\n",
+                "<event time=\"32522\" type=\"departure\" person=\"100\" link=\"link3\" legMode=\"walk\" computationalRoutingMode=\"car\"/>\n",
+                "<event time=\"32538\" type=\"travelled\" person=\"100\" distance=\"20\" mode=\"walk\"/>\n",
+                "<event time=\"32538\" type=\"arrival\" person=\"100\" link=\"link3\" legMode=\"walk\"/>\n",
+                "<event time=\"32539\" type=\"actstart\" person=\"100\" link=\"link3\" x=\"1100\" y=\"20\" actType=\"errands\"/>\n"
+            ]
+        );
+    }
 }

--- a/rust_qsim/tests/resources/events/expected_events.0.xml
+++ b/rust_qsim/tests/resources/events/expected_events.0.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<events version="1.0">
+    <event time="32400" type="actend" person="100" link="link1" x="5" y="10" actType="home"/>
+    <event time="32400.5" type="departure" person="100" link="link1" legMode="walk" computationalRoutingMode="car"/>
+    <event time="32408" type="travelled" person="100" distance="10" mode="walk"/>
+    <event time="32408" type="arrival" person="100" link="link1" legMode="walk"/>
+    <event time="32409" type="actstart" person="100" link="link1" x="5" y="0" actType="car interaction"/>
+    <event time="32409" type="actend" person="100" link="link1" x="5" y="0" actType="car interaction"/>
+    <event time="32409" type="departure" person="100" link="link1" legMode="car" computationalRoutingMode="car"/>
+    <event time="32409" type="PersonEntersVehicle" person="100" vehicle="100_car"/>
+    <event time="32409.123456789" type="vehicle enters traffic" person="100" link="link1" vehicle="100_car" networkMode="car" relativePosition="1"/>
+    <event time="32410" type="left link" link="link1" vehicle="100_car"/>
+    <event time="32410" type="entered link" link="link2" vehicle="100_car"/>
+    <event time="32511" type="left link" link="link2" vehicle="100_car"/>
+    <event time="32511" type="entered link" link="link3" vehicle="100_car"/>
+    <event time="32521" type="vehicle leaves traffic" person="100" link="link3" vehicle="100_car" networkMode="car" relativePosition="1"/>
+    <event time="32521" type="PersonLeavesVehicle" person="100" vehicle="100_car"/>
+    <event time="32521" type="arrival" person="100" link="link3" legMode="car"/>
+    <event time="32522" type="actstart" person="100" link="link3" x="1100" y="0" actType="car interaction"/>
+    <event time="32522" type="actend" person="100" link="link3" x="1100" y="0" actType="car interaction"/>
+    <event time="32522" type="departure" person="100" link="link3" legMode="walk" computationalRoutingMode="car"/>
+    <event time="32538" type="travelled" person="100" distance="20" mode="walk"/>
+    <event time="32538" type="arrival" person="100" link="link3" legMode="walk"/>
+    <event time="32539" type="actstart" person="100" link="link3" x="1100" y="20" actType="errands"/>
+</events>

--- a/rust_qsim/tests/resources/events/expected_events.1.xml
+++ b/rust_qsim/tests/resources/events/expected_events.1.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<events version="1.0">
+    <event time="32406" type="travelled" person="100" distance="10" mode="walk"/>
+</events>

--- a/rust_qsim/tests/test_events.rs
+++ b/rust_qsim/tests/test_events.rs
@@ -35,7 +35,8 @@ fn test_proto_to_xml() {
         &proto_folder,
         num_parts,
         PathBuf::from(&output_folder).join("events.xml.gz"),
-    );
+    )
+    .expect("Failed to convert proto events to xml");
 
     // assert origin xml = new xml
     let generated_file = PathBuf::from(&output_folder).join("events.xml.gz");


### PR DESCRIPTION
Adds a `read_xml_events` function for events, similar to the existing `read_proto_events`.
That is, given a folder, prefix and a number of parts, reads all events files corresponding to the name `{folder}/{prefix}.{i}.xml` for `i=0..num_parts`, and publishes the events to a given event manager.

Can also be set to read `xml.gz` files following the same naming structure.

Includes a test making sure that all events are correctly published, in chronological order, also when coming from several files.