### PR TITLE
[codex] Add prepare-for-sim hook

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -436,6 +436,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1778,6 +1797,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,6 +1941,7 @@ dependencies = [
  "protobuf-src",
  "quick-xml",
  "rand",
+ "rayon",
  "reqwest",
  "rust_qsim",
  "serde",

--- a/rust_qsim/Cargo.toml
+++ b/rust_qsim/Cargo.toml
@@ -52,6 +52,7 @@ csv = "1.4.0"
 inventory = "0.3.21"
 arrow2 = { version = "0.18.0", features = ["io_parquet", "io_parquet_compression"] }
 ordered-float = "5.3.0"
+rayon = "1.12.0"
 
 # arrow2 removed; we write parquet-proxy as JSON-lines implementation for now
 

--- a/rust_qsim/src/simulation/controller/controller.rs
+++ b/rust_qsim/src/simulation/controller/controller.rs
@@ -12,6 +12,7 @@ use crate::simulation::messaging::sim_communication::local_communicator::Channel
 use crate::simulation::population::agent_source::{
     DynAgentSource, IntoDynAgentSource, PopulationAgentSource,
 };
+use crate::simulation::scenario::prepare_for_sim::prepare_for_sim;
 use crate::simulation::scenario::{MutableScenario, ScenarioPartition};
 use crate::simulation::{controller, id, io};
 use derive_more::Debug;
@@ -211,7 +212,7 @@ impl Controller {
     }
 
     fn run_channel(&mut self) -> IntMap<u32, JoinHandle<()>> {
-        let scenario = {
+        let mut scenario = {
             let s = mem::replace(&mut self.scenario, Scenario::Partitioned);
             match s {
                 Scenario::Partitioned => {
@@ -222,6 +223,8 @@ impl Controller {
                 Scenario::Full(s) => s,
             }
         };
+
+        prepare_for_sim(&mut scenario).unwrap_or_else(|err| panic!("{err}"));
 
         // Is of type Vec<Option<>> because later we iteratively take the partition builder and construct
         // the actual partitions.

--- a/rust_qsim/src/simulation/io/xml/mod.rs
+++ b/rust_qsim/src/simulation/io/xml/mod.rs
@@ -129,6 +129,10 @@ pub fn write_to_file<T: Serialize>(serde_message: &T, path: impl AsRef<Path>, dt
     if path.as_ref().extension().unwrap().eq("gz") {
         let mut compressor = flate2::write::GzEncoder::new(file_writer, Compression::fast());
 
+        compressor
+            .write_all(b"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            .expect("Failed to write XML declaration");
+
         // write header. first: dtd spec
         compressor
             .write_all(dtd_spec.as_bytes())

--- a/rust_qsim/src/simulation/scenario/mod.rs
+++ b/rust_qsim/src/simulation/scenario/mod.rs
@@ -1,5 +1,6 @@
 pub mod network;
 pub mod population;
+pub mod prepare_for_sim;
 pub mod trip_structure_utils;
 pub mod vehicles;
 

--- a/rust_qsim/src/simulation/scenario/network.rs
+++ b/rust_qsim/src/simulation/scenario/network.rs
@@ -197,7 +197,7 @@ impl Network {
         self.links.get_mut(id).unwrap()
     }
 
-    fn partition_network(
+    pub fn partition_network(
         network: &mut Network,
         partition_method: &PartitionMethod,
         num_parts: u32,

--- a/rust_qsim/src/simulation/scenario/prepare_for_sim.rs
+++ b/rust_qsim/src/simulation/scenario/prepare_for_sim.rs
@@ -1,0 +1,117 @@
+use crate::simulation::id::Id;
+use crate::simulation::scenario::MutableScenario;
+use crate::simulation::scenario::population::InternalPerson;
+use rayon::prelude::*;
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[error("prepare-for-sim failed")]
+pub struct PrepareForSimError {
+    issues: Vec<PrepareForSimIssue>,
+}
+
+impl PrepareForSimError {
+    fn new(mut issues: Vec<PrepareForSimIssue>) -> Self {
+        issues.sort_by(|a, b| a.person_id.cmp(&b.person_id));
+        Self { issues }
+    }
+
+    pub fn issues(&self) -> &[PrepareForSimIssue] {
+        &self.issues
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrepareForSimIssue {
+    pub person_id: String,
+    pub message: String,
+}
+
+pub fn prepare_for_sim(scenario: &mut MutableScenario) -> Result<(), PrepareForSimError> {
+    let issues: Vec<_> = scenario
+        .population
+        .persons
+        .par_iter_mut()
+        .flat_map(|(_, person)| prepare_person(person))
+        .collect();
+
+    if issues.is_empty() {
+        Ok(())
+    } else {
+        Err(PrepareForSimError::new(issues))
+    }
+}
+
+fn prepare_person(_person: &mut InternalPerson) -> Vec<PrepareForSimIssue> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prepare_for_sim;
+    use crate::simulation::config::Config;
+    use crate::simulation::id::Id;
+    use crate::simulation::scenario::network::Network;
+    use crate::simulation::scenario::population::{
+        InternalActivity, InternalPerson, InternalPlan, Population,
+    };
+    use crate::simulation::scenario::vehicles::Garage;
+    use crate::simulation::scenario::{Coordinate, MutableScenario};
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    #[test]
+    fn prepare_for_sim_succeeds_for_empty_population() {
+        let mut scenario = scenario_with_population(Population::new());
+
+        prepare_for_sim(&mut scenario).unwrap();
+
+        assert!(scenario.population.persons.is_empty());
+    }
+
+    #[test]
+    fn prepare_for_sim_visits_population_without_moving_persons() {
+        let mut persons = HashMap::new();
+        persons.insert(Id::create("person-1"), person("person-1", "link-1"));
+        persons.insert(Id::create("person-2"), person("person-2", "link-2"));
+        let mut scenario = scenario_with_population(Population { persons });
+
+        prepare_for_sim(&mut scenario).unwrap();
+
+        assert_eq!(2, scenario.population.persons.len());
+        assert!(
+            scenario
+                .population
+                .persons
+                .contains_key(&Id::get_from_ext("person-1"))
+        );
+        assert!(
+            scenario
+                .population
+                .persons
+                .contains_key(&Id::get_from_ext("person-2"))
+        );
+    }
+
+    fn scenario_with_population(population: Population) -> MutableScenario {
+        MutableScenario {
+            network: Network::new(),
+            garage: Garage::default(),
+            population,
+            config: Arc::new(Config::default()),
+        }
+    }
+
+    fn person(id: &str, link_id: &str) -> InternalPerson {
+        let mut plan = InternalPlan::default();
+        plan.add_act(InternalActivity::new(
+            Coordinate::default(),
+            "act",
+            Id::create(link_id),
+            None,
+            None,
+            None,
+        ));
+        InternalPerson::new(Id::create(id), plan)
+    }
+}

--- a/rust_qsim/src/simulation/scenario/prepare_for_sim.rs
+++ b/rust_qsim/src/simulation/scenario/prepare_for_sim.rs
@@ -1,6 +1,8 @@
-use crate::simulation::id::Id;
+use crate::simulation::config::Config;
 use crate::simulation::scenario::MutableScenario;
+use crate::simulation::scenario::network::Network;
 use crate::simulation::scenario::population::InternalPerson;
+use crate::simulation::scenario::vehicles::Garage;
 use rayon::prelude::*;
 use thiserror::Error;
 
@@ -28,11 +30,17 @@ pub struct PrepareForSimIssue {
 }
 
 pub fn prepare_for_sim(scenario: &mut MutableScenario) -> Result<(), PrepareForSimError> {
+    let context = PrepareForSimContext {
+        network: &scenario.network,
+        garage: &scenario.garage,
+        config: scenario.config.as_ref(),
+    };
+
     let issues: Vec<_> = scenario
         .population
         .persons
         .par_iter_mut()
-        .flat_map(|(_, person)| prepare_person(person))
+        .flat_map(|(_, person)| prepare_person(&context, person))
         .collect();
 
     if issues.is_empty() {
@@ -42,7 +50,16 @@ pub fn prepare_for_sim(scenario: &mut MutableScenario) -> Result<(), PrepareForS
     }
 }
 
-fn prepare_person(_person: &mut InternalPerson) -> Vec<PrepareForSimIssue> {
+pub struct PrepareForSimContext<'a> {
+    pub network: &'a Network,
+    pub garage: &'a Garage,
+    pub config: &'a Config,
+}
+
+fn prepare_person(
+    _context: &PrepareForSimContext<'_>,
+    _person: &mut InternalPerson,
+) -> Vec<PrepareForSimIssue> {
     Vec::new()
 }
 


### PR DESCRIPTION
## Summary

Adds a parallel `prepare_for_sim` phase before scenario partitioning and simulation thread startup. The per-person task currently receives read-only scenario context and mutable access to the person, leaving concrete preparation rules for follow-up work.

## Validation

- `cargo fmt --check`
- `cargo test -p rust_qsim prepare_for_sim`