### PR TITLE
Fix from_proto_event() for activity events

### DIFF
--- a/rust_qsim/src/simulation/events/mod.rs
+++ b/rust_qsim/src/simulation/events/mod.rs
@@ -223,10 +223,16 @@ impl ActivityStartEvent {
             .person(Id::create(&event.attributes["person"].as_string()))
             .link(Id::create(&event.attributes["link"].as_string()))
             .act_type(Id::create(&event.attributes["act_type"].as_string()))
-            .coordinate(Some(Coordinate::new(
-                event.attributes["x"].as_double(),
-                event.attributes["y"].as_double(),
-            )))
+            .coordinate(event.attributes.get("x").map(|x| {
+                Coordinate::new(
+                    x.as_double(),
+                    event
+                        .attributes
+                        .get("y")
+                        .expect("y coordinate should be given if x coordinate is given")
+                        .as_double(),
+                )
+            }))
             .attributes(attrs)
             .build()
             .unwrap()
@@ -254,10 +260,16 @@ impl ActivityEndEvent {
             .person(Id::create(&event.attributes["person"].as_string()))
             .link(Id::create(&event.attributes["link"].as_string()))
             .act_type(Id::create(&event.attributes["act_type"].as_string()))
-            .coordinate(Some(Coordinate::new(
-                event.attributes["x"].as_double(),
-                event.attributes["y"].as_double(),
-            )))
+            .coordinate(event.attributes.get("x").map(|x| {
+                Coordinate::new(
+                    x.as_double(),
+                    event
+                        .attributes
+                        .get("y")
+                        .expect("y coordinate should be given if x coordinate is given")
+                        .as_double(),
+                )
+            }))
             .attributes(attrs)
             .build()
             .unwrap()


### PR DESCRIPTION
In PR #274, coordinates were made optional in activities and activity start and end events, and also in xml and proto event files.

However, when creating `ActivityStartEvents` (or end events) from proto, the corresponding functions currently panic if the proto file contains such an event without coordinates.

This PR fixes this.

In the future, when #275 is implemented, this will no longer be relevant.