### PR TITLE
Fix move_nodes and enhance travel time calculator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -328,6 +328,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +427,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "crc32fast"
@@ -855,6 +875,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -1219,6 +1240,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,9 +1349,9 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.6"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
+checksum = "ecbdfe44b1bd960b68170b417450a628c43f7cf56bb3c5317e61cb230ee7f226"
 dependencies = [
  "twox-hash",
 ]
@@ -1648,15 +1678,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,7 +1713,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "once_cell",
@@ -1712,7 +1733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1738,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.5"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
  "serde",
@@ -1769,32 +1790,20 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rayon"
@@ -1927,7 +1936,7 @@ dependencies = [
  "flate2",
  "futures",
  "inventory",
- "itertools",
+ "itertools 0.15.0",
  "keyed_priority_queue",
  "lz4",
  "lz4_flex",
@@ -3148,18 +3157,9 @@ checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "xml"
-version = "0.8.20"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede1c99c55b4b3ad0349018ef0eccbe954ce9c342334410707ee87177fcf2ab4"
-dependencies = [
- "xml-rs",
-]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "yoke"

--- a/rust_qsim/Cargo.toml
+++ b/rust_qsim/Cargo.toml
@@ -11,9 +11,9 @@ http = ["dep:reqwest"]
 [dependencies]
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.93"
-quick-xml = { version = "0.37.5", features = ["serialize"] }
+quick-xml = { version = "0.41.0", features = ["serialize"] }
 flate2 = { version = "1.0.24" }
-rand = "0.9.0"
+rand = "0.10.2"
 metis = "0.2.2"
 clap = { version = "4.0.29", features = ["derive"] }
 # dependencies for serialization with protobuf
@@ -24,14 +24,14 @@ serial_test = "3.2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3.0", features = ["json", "fmt", "std", "registry", "env-filter"] }
 tracing-appender = "0.2"
-itertools = "0.14.0"
+itertools = "0.15.0"
 assert_approx_eq = "1.1.0"
 nohash-hasher = "0.2.0"
 serde_path_to_error = "0.1.14"
 ahash = "0.8.11"
 keyed_priority_queue = "0.4.2"
-xml = "0.8.20"
-lz4_flex = "0.11.1"
+xml = "1.3.0"
+lz4_flex = "0.14.0"
 typetag = "0.2.18"
 serde_yaml = "0.9.34"
 tonic = "0.13.1"

--- a/rust_qsim/src/bin/neighbors.rs
+++ b/rust_qsim/src/bin/neighbors.rs
@@ -6,7 +6,9 @@ use ahash::HashSet;
 use clap::Parser;
 use tracing::info;
 
-use rust_qsim::simulation::config::{EdgeWeight, MetisOptions, PartitionMethod, VertexWeight};
+use rust_qsim::simulation::config::{
+    Config, EdgeWeight, MetisOptions, PartitionMethod, VertexWeight,
+};
 use rust_qsim::simulation::logging::init_std_out_logging_thread_local;
 use rust_qsim::simulation::network::LinkStorageCapacities;
 use rust_qsim::simulation::network::sim_network::SimNetworkPartition;
@@ -40,17 +42,12 @@ fn main() {
                 contiguous: true,
             }),
         );
-        let qsim_config = config::QSim::default();
-        let storage_capacities = LinkStorageCapacities::from_network(&net, &qsim_config);
+        let config = Config::default();
+        let storage_capacities = LinkStorageCapacities::from_network(&net, config.qsim());
         let distinct_partitions: HashSet<u32> = net.nodes().iter().map(|n| n.partition).collect();
         for partition in distinct_partitions {
-            let net_partition = SimNetworkPartition::from_network(
-                &net,
-                &storage_capacities,
-                partition,
-                &qsim_config,
-                config::DEFAULT_RANDOM_SEED,
-            );
+            let net_partition =
+                SimNetworkPartition::from_network(&net, &storage_capacities, partition, &config);
             let neighbors = net_partition.neighbors().len();
             let serialized = format!("{},{},{}\n", num_parts, partition, neighbors);
             writer

--- a/rust_qsim/src/bin/neighbors.rs
+++ b/rust_qsim/src/bin/neighbors.rs
@@ -8,6 +8,7 @@ use tracing::info;
 
 use rust_qsim::simulation::config::{EdgeWeight, MetisOptions, PartitionMethod, VertexWeight};
 use rust_qsim::simulation::logging::init_std_out_logging_thread_local;
+use rust_qsim::simulation::network::LinkStorageCapacities;
 use rust_qsim::simulation::network::sim_network::SimNetworkPartition;
 use rust_qsim::simulation::scenario::network::Network;
 use rust_qsim::simulation::{config, id};
@@ -39,12 +40,15 @@ fn main() {
                 contiguous: true,
             }),
         );
+        let qsim_config = config::QSim::default();
+        let storage_capacities = LinkStorageCapacities::from_network(&net, &qsim_config);
         let distinct_partitions: HashSet<u32> = net.nodes().iter().map(|n| n.partition).collect();
         for partition in distinct_partitions {
             let net_partition = SimNetworkPartition::from_network(
                 &net,
+                &storage_capacities,
                 partition,
-                &config::QSim::default(),
+                &qsim_config,
                 config::DEFAULT_RANDOM_SEED,
             );
             let neighbors = net_partition.neighbors().len();

--- a/rust_qsim/src/bin/neighbors.rs
+++ b/rust_qsim/src/bin/neighbors.rs
@@ -9,11 +9,11 @@ use tracing::info;
 use rust_qsim::simulation::config::{
     Config, EdgeWeight, MetisOptions, PartitionMethod, VertexWeight,
 };
+use rust_qsim::simulation::id;
 use rust_qsim::simulation::logging::init_std_out_logging_thread_local;
 use rust_qsim::simulation::network::LinkStorageCapacities;
 use rust_qsim::simulation::network::sim_network::SimNetworkPartition;
 use rust_qsim::simulation::scenario::network::Network;
-use rust_qsim::simulation::{config, id};
 
 // I would have expected, that we read already partitioned networks and write the neighbors of each partition to a file.
 // But we are partitioning the network in each iteration and write the neighbors of each partition to a file. paul, jan'25

--- a/rust_qsim/src/experiments/concurrent_dispatch.rs
+++ b/rust_qsim/src/experiments/concurrent_dispatch.rs
@@ -1,4 +1,4 @@
-use rand::Rng;
+use rand::RngExt;
 use std::sync::mpsc;
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;

--- a/rust_qsim/src/simulation/agents/agent_logic.rs
+++ b/rust_qsim/src/simulation/agents/agent_logic.rs
@@ -496,6 +496,7 @@ mod tests {
     use crate::simulation::scenario::population::{
         InternalActivity, InternalLeg, InternalPlan, InternalRoute,
     };
+    use macros::deterministic_id_test;
     use uuid::Uuid;
 
     fn make_activity(act_type: &str, link: &str) -> InternalActivity {
@@ -529,7 +530,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn test_replace_next_trip_basic() {
         // Plan: home --leg1--> work --leg2--> shop
         let mut plan = InternalPlan::default();

--- a/rust_qsim/src/simulation/controller/controller.rs
+++ b/rust_qsim/src/simulation/controller/controller.rs
@@ -10,6 +10,7 @@ use crate::simulation::framework_events::{
     MobsimListenerRegisterFn, PartitionListenerRegisterFn,
 };
 use crate::simulation::id::Id;
+use crate::simulation::network::LinkStorageCapacities;
 use crate::simulation::population::agent_source::{
     DynAgentSource, IntoDynAgentSource, PopulationAgentSource,
 };
@@ -33,6 +34,7 @@ use tracing::info;
 #[derive(Debug)]
 pub struct Controller {
     scenario: ControllerScenario,
+    link_storage_capacities: LinkStorageCapacities,
     config: Arc<Config>,
     #[debug(skip)]
     agent_source: DynAgentSource,
@@ -90,6 +92,10 @@ impl ControllerBuilder {
             register_fn(&mut controller_event_manager);
         }
 
+        let link_storage_capacities = LinkStorageCapacities::from_network(
+            &self.scenario.network,
+            self.scenario.config.qsim(),
+        );
         let scenario: ControllerScenario = self.scenario.into();
         let config = scenario.core.config.clone();
 
@@ -97,6 +103,7 @@ impl ControllerBuilder {
 
         Ok(Controller {
             scenario,
+            link_storage_capacities,
             config,
             agent_source: self.agent_source,
             controller_events_manager: controller_event_manager,
@@ -337,7 +344,9 @@ impl Controller {
 
         prepare_for_sim(&mut self.scenario, &self.trip_router)
             .unwrap_or_else(|err| panic!("{err}: {:?}", err.issues()));
-        let inputs = self.scenario.split_for_mobsim();
+        let inputs = self
+            .scenario
+            .split_for_mobsim(&self.link_storage_capacities);
         let agents = mobsim_workers.run_mobsim(iteration, is_last_iteration, inputs);
 
         self.controller_events_manager
@@ -428,7 +437,11 @@ impl Controller {
             ),
         );
 
-        self.scenario.core.network.to_file(&net_out_path);
+        let attribute_overrides = self.link_storage_capacities.attribute_overrides();
+        self.scenario
+            .core
+            .network
+            .to_file_with_link_attribute_overrides(&net_out_path, &attribute_overrides);
     }
 
     fn write_output_population(&mut self, output_path: impl AsRef<Path>) {

--- a/rust_qsim/src/simulation/controller/mod.rs
+++ b/rust_qsim/src/simulation/controller/mod.rs
@@ -781,7 +781,6 @@ mod tests {
     use super::{MobsimWorkerPool, MobsimWorkerPoolArgumentsBuilder, ReplanningPool};
     use crate::simulation::config::Config;
     use crate::simulation::id::Id;
-    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::sim_network::SimNetworkPartition;
     use crate::simulation::population::agent_source::PopulationAgentSource;
     use crate::simulation::scenario::network::Network;
@@ -845,15 +844,8 @@ mod tests {
     }
 
     fn empty_mobsim_input(scenario: &ScenarioCore) -> MobsimInput {
-        let storage_capacities =
-            LinkStorageCapacities::from_network(&scenario.network, scenario.config.qsim());
-        let network_partition = SimNetworkPartition::from_network(
-            &scenario.network,
-            &storage_capacities,
-            0,
-            scenario.config.qsim(),
-            scenario.config.computational_setup().random_seed,
-        );
+        let network_partition =
+            SimNetworkPartition::from_network_for_test(&scenario.network, 0, &scenario.config);
 
         MobsimInput {
             partition: MobsimScenarioPartition {

--- a/rust_qsim/src/simulation/controller/mod.rs
+++ b/rust_qsim/src/simulation/controller/mod.rs
@@ -781,6 +781,7 @@ mod tests {
     use super::{MobsimWorkerPool, MobsimWorkerPoolArgumentsBuilder, ReplanningPool};
     use crate::simulation::config::Config;
     use crate::simulation::id::Id;
+    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::sim_network::SimNetworkPartition;
     use crate::simulation::population::agent_source::PopulationAgentSource;
     use crate::simulation::scenario::network::Network;
@@ -844,8 +845,11 @@ mod tests {
     }
 
     fn empty_mobsim_input(scenario: &ScenarioCore) -> MobsimInput {
+        let storage_capacities =
+            LinkStorageCapacities::from_network(&scenario.network, scenario.config.qsim());
         let network_partition = SimNetworkPartition::from_network(
             &scenario.network,
+            &storage_capacities,
             0,
             scenario.config.qsim(),
             scenario.config.computational_setup().random_seed,

--- a/rust_qsim/src/simulation/events/mod.rs
+++ b/rust_qsim/src/simulation/events/mod.rs
@@ -552,6 +552,34 @@ impl PtTeleportationArrivalEvent {
     }
 }
 
+#[event_struct]
+pub struct PersonStuckEvent {
+    pub time: SimTime,
+    pub person: Id<InternalPerson>,
+    pub link: Id<Link>,
+    pub leg_mode: Id<String>,
+    pub reason: String,
+    #[builder(default)]
+    pub attributes: InternalAttributes,
+}
+
+impl PersonStuckEvent {
+    pub const TYPE: &'static str = "stuckAndAbort";
+    pub fn from_proto_event(event: &crate::generated::events::GenericEvent, time: SimTime) -> Self {
+        let attrs = InternalAttributes::from(&event.attributes);
+        assert!(event.r#type.eq(Self::TYPE));
+        PersonStuckEventBuilder::default()
+            .time(time)
+            .person(Id::create(&event.attributes["person"].as_string()))
+            .leg_mode(Id::create(&event.attributes["mode"].as_string()))
+            .link(Id::create(&event.attributes["link"].as_string()))
+            .reason(event.attributes["reason"].as_string())
+            .attributes(attrs)
+            .build()
+            .unwrap()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::simulation::events::{

--- a/rust_qsim/src/simulation/framework_events/mod.rs
+++ b/rust_qsim/src/simulation/framework_events/mod.rs
@@ -299,6 +299,7 @@ impl Default for FrameworkEventsManager<ControllerEvent> {
 mod tests {
     use super::*;
     use crate::simulation::time::SimTime;
+    use macros::deterministic_id_test;
     use std::cell::RefCell;
     use std::rc::Rc;
 
@@ -489,7 +490,7 @@ mod tests {
         assert_eq!(vec!["high", "default", "low"], order.borrow().clone());
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn partition_events_use_partition_origin_and_invoke_callbacks() {
         let mut manager = PartitionEventsManager::for_partition(4, 6);
         let received: Rc<RefCell<Vec<PartitionRuntimeEvent>>> = Rc::new(RefCell::new(Vec::new()));
@@ -542,7 +543,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn partition_next_iteration_resets_seq_counter() {
         let mut manager = PartitionEventsManager::for_partition(3, 8);
 
@@ -569,7 +570,7 @@ mod tests {
         assert_eq!(0, second.meta.seq_no);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn partition_reset_iteration_sets_iteration_and_keeps_callbacks() {
         let mut manager = PartitionEventsManager::for_partition(3, 8);
         let received: Rc<RefCell<Vec<PartitionRuntimeEvent>>> = Rc::new(RefCell::new(Vec::new()));
@@ -600,7 +601,7 @@ mod tests {
         assert_eq!(2, received.borrow().len());
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn partition_callbacks_are_called_by_descending_priority() {
         let mut manager = PartitionEventsManager::for_partition(5, 0);
         let order: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));

--- a/rust_qsim/src/simulation/io/proto/proto_events.rs
+++ b/rust_qsim/src/simulation/io/proto/proto_events.rs
@@ -1,7 +1,7 @@
 use crate::generated::events::{GenericEvent, TimeStep};
 use crate::generated::general::AttributeValue;
 use crate::simulation::events::{
-    ActivityEndEvent, ActivityStartEvent, DynEq, EventHandlerRegisterFn, EventTrait, EventsManager,
+    ActivityEndEvent, ActivityStartEvent, EventHandlerRegisterFn, EventTrait, EventsManager,
     LinkEnterEvent, LinkLeaveEvent, PersonArrivalEvent, PersonDepartureEvent,
     PersonEntersVehicleEvent, PersonLeavesVehicleEvent, PersonStuckEvent,
     PtTeleportationArrivalEvent, TeleportationArrivalEvent, VehicleEntersTrafficEvent,

--- a/rust_qsim/src/simulation/io/proto/proto_events.rs
+++ b/rust_qsim/src/simulation/io/proto/proto_events.rs
@@ -1,7 +1,7 @@
 use crate::generated::events::{GenericEvent, TimeStep};
 use crate::generated::general::AttributeValue;
 use crate::simulation::events::{
-    ActivityEndEvent, ActivityStartEvent, EventHandlerRegisterFn, EventTrait, EventsManager,
+    ActivityEndEvent, ActivityStartEvent, DynEq, EventHandlerRegisterFn, EventTrait, EventsManager,
     LinkEnterEvent, LinkLeaveEvent, PersonArrivalEvent, PersonDepartureEvent,
     PersonEntersVehicleEvent, PersonLeavesVehicleEvent, PersonStuckEvent,
     PtTeleportationArrivalEvent, TeleportationArrivalEvent, VehicleEntersTrafficEvent,
@@ -300,6 +300,32 @@ impl From<&VehicleLeavesTrafficEvent> for GenericEvent {
     }
 }
 
+impl From<&PersonStuckEvent> for GenericEvent {
+    fn from(value: &PersonStuckEvent) -> Self {
+        let mut attributes = HashMap::new();
+        attributes.insert(
+            "person".to_string(),
+            AttributeValue::from(value.person.external()),
+        );
+        attributes.insert(
+            "link".to_string(),
+            AttributeValue::from(value.link.external()),
+        );
+        attributes.insert(
+            "leg_mode".to_string(),
+            AttributeValue::from(value.leg_mode.external()),
+        );
+        attributes.insert(
+            "reason".to_string(),
+            AttributeValue::from(value.reason.to_string()),
+        );
+        GenericEvent {
+            r#type: value.type_().to_string(),
+            attributes,
+        }
+    }
+}
+
 impl From<&crate::simulation::events::GenericEvent> for GenericEvent {
     fn from(value: &crate::simulation::events::GenericEvent) -> Self {
         let mut attributes = HashMap::new();
@@ -384,6 +410,8 @@ impl ProtoEventsWriter {
         } else if let Some(event) = event.as_any().downcast_ref::<VehicleEntersTrafficEvent>() {
             GenericEvent::from(event)
         } else if let Some(event) = event.as_any().downcast_ref::<VehicleLeavesTrafficEvent>() {
+            GenericEvent::from(event)
+        } else if let Some(event) = event.as_any().downcast_ref::<PersonStuckEvent>() {
             GenericEvent::from(event)
         } else {
             // TODO use general event here and log warning

--- a/rust_qsim/src/simulation/io/proto/proto_events.rs
+++ b/rust_qsim/src/simulation/io/proto/proto_events.rs
@@ -3,8 +3,9 @@ use crate::generated::general::AttributeValue;
 use crate::simulation::events::{
     ActivityEndEvent, ActivityStartEvent, EventHandlerRegisterFn, EventTrait, EventsManager,
     LinkEnterEvent, LinkLeaveEvent, PersonArrivalEvent, PersonDepartureEvent,
-    PersonEntersVehicleEvent, PersonLeavesVehicleEvent, PtTeleportationArrivalEvent,
-    TeleportationArrivalEvent, VehicleEntersTrafficEvent, VehicleLeavesTrafficEvent,
+    PersonEntersVehicleEvent, PersonLeavesVehicleEvent, PersonStuckEvent,
+    PtTeleportationArrivalEvent, TeleportationArrivalEvent, VehicleEntersTrafficEvent,
+    VehicleLeavesTrafficEvent,
 };
 use crate::simulation::time::SimTime;
 use prost::Message;
@@ -532,6 +533,7 @@ pub fn process_events(time: SimTime, events: &Vec<GenericEvent>, manager: &mut E
             PtTeleportationArrivalEvent::TYPE => Box::new(PtTeleportationArrivalEvent::from_proto_event(proto_event, time)),
             VehicleEntersTrafficEvent::TYPE => Box::new(VehicleEntersTrafficEvent::from_proto_event(proto_event, time)),
             VehicleLeavesTrafficEvent::TYPE => Box::new(VehicleLeavesTrafficEvent::from_proto_event(proto_event, time)),
+            PersonStuckEvent::TYPE => Box::new(PersonStuckEvent::from_proto_event(proto_event, time)),
             _ => panic!("Unknown event type: {:?}", type_),
         };
         manager.process_event(internal_event.as_ref());

--- a/rust_qsim/src/simulation/io/proto/proto_network.rs
+++ b/rust_qsim/src/simulation/io/proto/proto_network.rs
@@ -1,6 +1,8 @@
 use crate::generated::general::Coordinate;
 use crate::generated::network::{Link, Node};
-use crate::simulation::scenario::network::Network;
+use crate::simulation::scenario::network::{
+    LinkAttributeOverrides, Network, merged_link_attributes,
+};
 use std::path::Path;
 use tracing::info;
 
@@ -13,14 +15,30 @@ pub fn load_from_proto(path: &Path) -> Network {
 }
 
 pub fn write_to_proto(network: &Network, path: &Path) {
+    write_to_proto_with_link_attribute_overrides(network, path, &LinkAttributeOverrides::default());
+}
+
+pub(crate) fn write_to_proto_with_link_attribute_overrides(
+    network: &Network,
+    path: &Path,
+    overrides: &LinkAttributeOverrides,
+) {
     info!("Start writing proto network to path: {path:?}");
-    let wire_network = crate::generated::network::Network::from(network);
+    let wire_network =
+        crate::generated::network::Network::from_with_link_attribute_overrides(network, overrides);
     crate::generated::write_to_file(wire_network, path);
     info!("Finished writing proto network to path: {path:?}");
 }
 
 impl crate::generated::network::Network {
     pub fn from(network: &Network) -> Self {
+        Self::from_with_link_attribute_overrides(network, &LinkAttributeOverrides::default())
+    }
+
+    pub(crate) fn from_with_link_attribute_overrides(
+        network: &Network,
+        overrides: &LinkAttributeOverrides,
+    ) -> Self {
         info!("Converting Network into wire format");
         let nodes: Vec<_> = network
             .nodes()
@@ -39,16 +57,20 @@ impl crate::generated::network::Network {
         let links: Vec<_> = network
             .links()
             .iter()
-            .map(|l| Link {
-                id: l.id.external().to_string(),
-                from: l.from.external().to_string(),
-                to: l.to.external().to_string(),
-                length: l.length,
-                capacity: l.capacity,
-                freespeed: l.freespeed,
-                permlanes: l.permlanes,
-                modes: l.modes.iter().map(|id| id.external().to_string()).collect(),
-                partition: l.partition,
+            .map(|l| {
+                let attributes = merged_link_attributes(l, overrides).as_cloned_map();
+                Link {
+                    id: l.id.external().to_string(),
+                    from: l.from.external().to_string(),
+                    to: l.to.external().to_string(),
+                    length: l.length,
+                    capacity: l.capacity,
+                    freespeed: l.freespeed,
+                    permlanes: l.permlanes,
+                    modes: l.modes.iter().map(|id| id.external().to_string()).collect(),
+                    partition: l.partition,
+                    attributes,
+                }
             })
             .collect();
 
@@ -62,9 +84,11 @@ impl crate::generated::network::Network {
 
 #[cfg(test)]
 mod tests {
+    use crate::simulation::InternalAttributes;
     use crate::simulation::id::Id;
+    use crate::simulation::network::STORAGE_CAPACITY_USED_IN_QSIM;
     use crate::simulation::scenario::Coordinate;
-    use crate::simulation::scenario::network::{Network, Node};
+    use crate::simulation::scenario::network::{Link, LinkAttributeOverrides, Network, Node};
     use macros::deterministic_id_test;
 
     #[deterministic_id_test]
@@ -84,5 +108,46 @@ mod tests {
         assert_eq!(1.0, node.coord.x);
         assert_eq!(2.0, node.coord.y);
         assert_eq!(0., node.coord.z);
+    }
+
+    #[deterministic_id_test]
+    fn storage_capacity_attribute_overlay_round_trips_through_protobuf_without_mutating_network() {
+        let mut network = Network::new();
+        let from = Node::new(Id::create("from"), Coordinate::default(), 0, 1);
+        let to = Node::new(Id::create("to"), Coordinate::default(), 0, 1);
+        let link_id = Id::create("link");
+        let link = Link::new_with_default(link_id.clone(), &from, &to);
+        network.add_node(from);
+        network.add_node(to);
+        network.add_link(link);
+
+        let mut link_attributes = InternalAttributes::default();
+        link_attributes.insert(STORAGE_CAPACITY_USED_IN_QSIM, 200.);
+        let mut overrides = LinkAttributeOverrides::default();
+        overrides.insert(link_id.clone(), link_attributes);
+
+        let wire = crate::generated::network::Network::from_with_link_attribute_overrides(
+            &network, &overrides,
+        );
+        assert_eq!(
+            Some(200.),
+            wire.links[0].attributes[STORAGE_CAPACITY_USED_IN_QSIM].as_double_opt()
+        );
+
+        let round_trip = Network::from(wire);
+        assert_eq!(
+            Some(200.),
+            round_trip
+                .get_link(&link_id)
+                .attributes
+                .get::<f64>(STORAGE_CAPACITY_USED_IN_QSIM)
+        );
+        assert_eq!(
+            None,
+            network
+                .get_link(&link_id)
+                .attributes
+                .get::<f64>(STORAGE_CAPACITY_USED_IN_QSIM)
+        );
     }
 }

--- a/rust_qsim/src/simulation/io/proto/proto_population.rs
+++ b/rust_qsim/src/simulation/io/proto/proto_population.rs
@@ -218,7 +218,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    #[test]
+    #[deterministic_id_test]
     fn activity_coordinate_round_trip_preserves_none_z() {
         Id::<String>::create("home");
         let activity = InternalActivity::new(
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(Some(Duration::from_nanos(3_500_000)), round_trip.max_dur);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn leg_round_trip_preserves_sub_millisecond_times() {
         Id::<String>::create("walk");
         let route = InternalRoute::Generic(InternalGenericRoute::new(
@@ -302,7 +302,7 @@ mod tests {
         assert_eq!(Some(42.5), round_trip.score);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn person_to_proto_always_writes_subpopulation() {
         let person = InternalPerson::new(Id::create("1"), InternalPlan::default());
 
@@ -311,7 +311,7 @@ mod tests {
         assert_eq!(Some("person".to_string()), wire.subpopulation);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn person_from_proto_preserves_subpopulation() {
         Id::<InternalPerson>::create("proto-subpopulation-freight");
         let person = InternalPerson::from(Person {
@@ -324,7 +324,7 @@ mod tests {
         assert_eq!("freight", person.subpopulation().external());
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn person_from_proto_defaults_missing_subpopulation_to_person() {
         Id::<InternalPerson>::create("proto-subpopulation-default");
         let person = InternalPerson::from(Person {

--- a/rust_qsim/src/simulation/io/proto/types/network.proto
+++ b/rust_qsim/src/simulation/io/proto/types/network.proto
@@ -26,4 +26,5 @@ message Link {
   double permlanes = 7;
   repeated string modes = 8;
   uint32 partition = 9;
+  map<string, general.AttributeValue> attributes = 10;
 }

--- a/rust_qsim/src/simulation/io/xml/events.rs
+++ b/rust_qsim/src/simulation/io/xml/events.rs
@@ -30,26 +30,57 @@ use crate::simulation::scenario::vehicles::InternalVehicle;
 use crate::simulation::time::SimTime;
 
 pub struct XmlEventsWriter {
-    writer: Mutex<Box<dyn Write + Send>>,
+    writer: Mutex<Option<XmlEventsOutputWriter>>,
+}
+
+enum XmlEventsOutputWriter {
+    Plain(BufWriter<File>),
+    Gz(GzEncoder<File>),
+    Zst(ZstdEncoder<'static, File>),
+}
+
+impl XmlEventsOutputWriter {
+    fn new(path: impl AsRef<Path>) -> Self {
+        let file = File::create(&path).expect("Failed to create File.");
+        match path.as_ref().extension().unwrap().to_str() {
+            Some("gz") => Self::Gz(GzEncoder::new(file, Compression::fast())),
+            Some("zst") => {
+                Self::Zst(ZstdEncoder::new(file, 0).expect("Failed to create zstd encoder"))
+            }
+            _ => Self::Plain(BufWriter::new(file)),
+        }
+    }
+
+    fn write_all(&mut self, bytes: &[u8]) {
+        match self {
+            Self::Plain(writer) => writer.write_all(bytes),
+            Self::Gz(writer) => writer.write_all(bytes),
+            Self::Zst(writer) => writer.write_all(bytes),
+        }
+        .expect("Error while writing event");
+    }
+
+    fn finish(self) {
+        match self {
+            Self::Plain(mut writer) => writer.flush().expect("Failed to flush events."),
+            Self::Gz(writer) => {
+                writer.finish().expect("Failed to finish gzip events.");
+            }
+            Self::Zst(writer) => {
+                writer.finish().expect("Failed to finish zstd events.");
+            }
+        }
+    }
 }
 
 impl XmlEventsWriter {
     pub fn new(path: impl AsRef<Path>) -> Self {
         info!("Creating file: {:?}", path.as_ref());
-        let file = File::create(&path).expect("Failed to create File.");
-        let mut writer: Box<dyn Write + Send> = match path.as_ref().extension().unwrap().to_str() {
-            Some("gz") => Box::new(GzEncoder::new(file, Compression::fast())),
-            Some("zst") => {
-                Box::new(ZstdEncoder::new(file, 0).expect("Failed to create zstd encoder"))
-            }
-            _ => Box::new(BufWriter::new(file)),
-        };
+        let mut writer = XmlEventsOutputWriter::new(path);
         let header = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<events version=\"1.0\">\n";
-        writer
-            .write_all(header.as_bytes())
-            .expect("Failed to write events file header");
+        writer.write_all(header.as_bytes());
         XmlEventsWriter {
-            writer: Mutex::new(writer),
+            writer: Mutex::new(Some(writer)),
         }
     }
 
@@ -185,18 +216,21 @@ impl XmlEventsWriter {
     }
 
     fn write(&self, text: &str) {
-        let mut writer = self.writer.lock().expect("Failed to lock writer");
-        writer
-            .write_all(text.as_bytes())
-            .expect("Error while writing event");
+        let mut guard = self.writer.lock().expect("Failed to lock writer");
+        let writer = guard
+            .as_mut()
+            .expect("Cannot write event after events writer was finished");
+        writer.write_all(text.as_bytes());
     }
 
     pub fn finish(&self) {
-        let closing_tag = "</events>";
-        self.write(closing_tag);
-        info!("Finishing Events File. Calling flush on Buffered Writer.");
-        let mut writer = self.writer.lock().expect("Failed to lock writer");
-        writer.flush().expect("Failed to flush events.");
+        info!("Finishing Events File.");
+        let mut guard = self.writer.lock().expect("Failed to lock writer");
+        let Some(mut writer) = guard.take() else {
+            return;
+        };
+        writer.write_all(b"</events>");
+        writer.finish();
     }
 
     pub fn register_fn(path: impl AsRef<Path> + Send + 'static) -> Box<EventHandlerRegisterFn> {
@@ -484,6 +518,7 @@ mod tests {
     use crate::simulation::time::SimTime;
     use macros::deterministic_id_test;
     use std::fs;
+    use std::io::Read;
     use std::path::PathBuf;
 
     #[deterministic_id_test]
@@ -556,5 +591,67 @@ mod tests {
         assert_eq!(Id::create("link-1"), parsed_event.link);
         assert_eq!(Id::create("home"), parsed_event.act_type);
         assert_eq!(Coordinate::new_2d(1.0, 2.0), parsed_event.coordinate);
+    }
+
+    #[deterministic_id_test]
+    fn gzip_xml_event_writer_finishes_compressed_stream() {
+        assert_compressed_event_stream_finishes(
+            PathBuf::from("./test_output/io/xml_events/gzip_finished/events.xml.gz"),
+            read_gzip_to_string,
+        );
+    }
+
+    #[deterministic_id_test]
+    fn zstd_xml_event_writer_finishes_compressed_stream() {
+        assert_compressed_event_stream_finishes(
+            PathBuf::from("./test_output/io/xml_events/zstd_finished/events.xml.zst"),
+            read_zstd_to_string,
+        );
+    }
+
+    fn assert_compressed_event_stream_finishes(
+        path: PathBuf,
+        read_to_string: fn(&PathBuf) -> String,
+    ) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+        let event: Box<dyn EventTrait> = Box::new(
+            ActivityStartEventBuilder::default()
+                .time(SimTime::from_nanos(42_123_456_789))
+                .person(Id::create("person-1"))
+                .link(Id::create("link-1"))
+                .act_type(Id::create("home"))
+                .coordinate(Coordinate::new_2d(1.0, 2.0))
+                .build()
+                .unwrap(),
+        );
+
+        let writer = XmlEventsWriter::new(&path);
+        writer.on_any(event.as_ref());
+        writer.finish();
+        writer.finish();
+
+        let xml = read_to_string(&path);
+        assert!(xml.contains("</events>"));
+
+        let mut reader = XmlEventsReader::new(&path);
+        let (time, _) = reader.read_next().unwrap();
+        assert_eq!(SimTime::from_nanos(42_123_456_789), time);
+    }
+
+    fn read_gzip_to_string(path: &PathBuf) -> String {
+        let file = fs::File::open(path).unwrap();
+        let mut decoder = flate2::read::GzDecoder::new(file);
+        let mut output = String::new();
+        decoder.read_to_string(&mut output).unwrap();
+        output
+    }
+
+    fn read_zstd_to_string(path: &PathBuf) -> String {
+        let file = fs::File::open(path).unwrap();
+        let mut decoder = zstd::stream::read::Decoder::new(file).unwrap();
+        let mut output = String::new();
+        decoder.read_to_string(&mut output).unwrap();
+        output
     }
 }

--- a/rust_qsim/src/simulation/io/xml/events.rs
+++ b/rust_qsim/src/simulation/io/xml/events.rs
@@ -520,12 +520,16 @@ fn handle_person_stuck(attr: Vec<OwnedAttribute>) -> Box<dyn EventTrait> {
     let person: Id<InternalPerson> = Id::create(value_from_name(&attr, "person").unwrap());
     let link: Id<Link> = Id::create(value_from_name(&attr, "link").unwrap());
     let leg_mode: Id<String> = Id::create(value_from_name(&attr, "legMode").unwrap());
+    let reason = value_from_name(&attr, "reason")
+        .cloned()
+        .unwrap_or_default();
     Box::new(
         PersonStuckEventBuilder::default()
             .time(time)
             .person(person)
             .link(link)
             .leg_mode(leg_mode)
+            .reason(reason)
             .build()
             .unwrap(),
     )

--- a/rust_qsim/src/simulation/io/xml/events.rs
+++ b/rust_qsim/src/simulation/io/xml/events.rs
@@ -14,7 +14,7 @@ use zstd::stream::write::Encoder as ZstdEncoder;
 
 use crate::simulation::events::{
     ActivityEndEvent, ActivityEndEventBuilder, ActivityStartEvent, ActivityStartEventBuilder,
-    DynEq, EventHandlerRegisterFn, EventTrait, EventsManager, GenericEvent, LinkEnterEvent,
+    EventHandlerRegisterFn, EventTrait, EventsManager, GenericEvent, LinkEnterEvent,
     LinkEnterEventBuilder, LinkLeaveEvent, LinkLeaveEventBuilder, PersonArrivalEvent,
     PersonArrivalEventBuilder, PersonDepartureEvent, PersonDepartureEventBuilder,
     PersonEntersVehicleEvent, PersonEntersVehicleEventBuilder, PersonLeavesVehicleEvent,

--- a/rust_qsim/src/simulation/io/xml/events.rs
+++ b/rust_qsim/src/simulation/io/xml/events.rs
@@ -14,13 +14,14 @@ use zstd::stream::write::Encoder as ZstdEncoder;
 
 use crate::simulation::events::{
     ActivityEndEvent, ActivityEndEventBuilder, ActivityStartEvent, ActivityStartEventBuilder,
-    EventHandlerRegisterFn, EventTrait, EventsManager, GenericEvent, LinkEnterEvent,
+    DynEq, EventHandlerRegisterFn, EventTrait, EventsManager, GenericEvent, LinkEnterEvent,
     LinkEnterEventBuilder, LinkLeaveEvent, LinkLeaveEventBuilder, PersonArrivalEvent,
     PersonArrivalEventBuilder, PersonDepartureEvent, PersonDepartureEventBuilder,
     PersonEntersVehicleEvent, PersonEntersVehicleEventBuilder, PersonLeavesVehicleEvent,
-    PersonLeavesVehicleEventBuilder, PtTeleportationArrivalEvent, TeleportationArrivalEvent,
-    TeleportationArrivalEventBuilder, VehicleEntersTrafficEvent, VehicleEntersTrafficEventBuilder,
-    VehicleLeavesTrafficEvent, VehicleLeavesTrafficEventBuilder,
+    PersonLeavesVehicleEventBuilder, PersonStuckEvent, PersonStuckEventBuilder,
+    PtTeleportationArrivalEvent, TeleportationArrivalEvent, TeleportationArrivalEventBuilder,
+    VehicleEntersTrafficEvent, VehicleEntersTrafficEventBuilder, VehicleLeavesTrafficEvent,
+    VehicleLeavesTrafficEventBuilder,
 };
 use crate::simulation::id::Id;
 use crate::simulation::scenario::Coordinate;
@@ -206,6 +207,16 @@ impl XmlEventsWriter {
                 ev.network_mode,
                 ev.relative_position
             )
+        } else if let Some(stuck) = e.as_any().downcast_ref::<PersonStuckEvent>() {
+            format!(
+                "<event time=\"{}\" type=\"{}\" person=\"{}\" link=\"{}\" legMode=\"{}\" reason=\"{}\"/>\n",
+                stuck.time().format_decimal_seconds(),
+                stuck.type_(),
+                stuck.person,
+                stuck.link,
+                stuck.leg_mode,
+                stuck.reason
+            )
         } else {
             panic!("Unknown event type");
         }
@@ -297,17 +308,18 @@ impl XmlEventsReader {
 fn handle(attr: Vec<OwnedAttribute>) -> Box<dyn EventTrait> {
     let ev_type = &attr.get(1).unwrap().value;
     match ev_type.as_str() {
-        "actend" => handle_act_end(attr),
-        "departure" => handle_departure(attr),
-        "travelled" => travelled(attr),
-        "arrival" => handle_arrival(attr),
-        "actstart" => handle_act_start(attr),
-        "PersonEntersVehicle" => handle_person_enters_veh(attr),
-        "PersonLeavesVehicle" => handle_person_leaves_veh(attr),
-        "entered link" => handle_link_enter(attr),
-        "left link" => handle_link_leave(attr),
-        "vehicle enters traffic" => handle_vehicle_enters_traffic(attr),
-        "vehicle leaves traffic" => handle_vehicle_leaves_traffic(attr),
+        ActivityEndEvent::TYPE => handle_act_end(attr),
+        PersonDepartureEvent::TYPE => handle_departure(attr),
+        TeleportationArrivalEvent::TYPE => travelled(attr),
+        PersonArrivalEvent::TYPE => handle_arrival(attr),
+        ActivityStartEvent::TYPE => handle_act_start(attr),
+        PersonEntersVehicleEvent::TYPE => handle_person_enters_veh(attr),
+        PersonLeavesVehicleEvent::TYPE => handle_person_leaves_veh(attr),
+        LinkEnterEvent::TYPE => handle_link_enter(attr),
+        LinkLeaveEvent::TYPE => handle_link_leave(attr),
+        VehicleEntersTrafficEvent::TYPE => handle_vehicle_enters_traffic(attr),
+        VehicleLeavesTrafficEvent::TYPE => handle_vehicle_leaves_traffic(attr),
+        PersonStuckEvent::TYPE => handle_person_stuck(attr),
         _ => panic!("Unknown event type {ev_type}"),
     }
 }
@@ -498,6 +510,22 @@ fn handle_link_leave(attr: Vec<OwnedAttribute>) -> Box<dyn EventTrait> {
             .time(time)
             .link(link)
             .vehicle(vehicle)
+            .build()
+            .unwrap(),
+    )
+}
+
+fn handle_person_stuck(attr: Vec<OwnedAttribute>) -> Box<dyn EventTrait> {
+    let time = SimTime::parse_decimal_seconds(value_from_name(&attr, "time").unwrap()).unwrap();
+    let person: Id<InternalPerson> = Id::create(value_from_name(&attr, "person").unwrap());
+    let link: Id<Link> = Id::create(value_from_name(&attr, "link").unwrap());
+    let leg_mode: Id<String> = Id::create(value_from_name(&attr, "legMode").unwrap());
+    Box::new(
+        PersonStuckEventBuilder::default()
+            .time(time)
+            .person(person)
+            .link(link)
+            .leg_mode(leg_mode)
             .build()
             .unwrap(),
     )

--- a/rust_qsim/src/simulation/io/xml/network.rs
+++ b/rust_qsim/src/simulation/io/xml/network.rs
@@ -1,6 +1,8 @@
 use crate::simulation::io::xml;
 use crate::simulation::io::xml::attributes::{IOAttribute, IOAttributes};
-use crate::simulation::scenario::network::Network;
+use crate::simulation::scenario::network::{
+    LinkAttributeOverrides, Network, merged_link_attributes,
+};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::path::Path;
@@ -11,7 +13,15 @@ pub(crate) fn load_from_xml(path: &Path) -> Network {
     Network::from(io_net)
 }
 
-pub(crate) fn write_to_xml(network: &Network, path: &Path) {
+pub(crate) fn write_to_xml_with_link_attribute_overrides(
+    network: &Network,
+    path: &Path,
+    overrides: &LinkAttributeOverrides,
+) {
+    to_io_network(network, overrides).to_file(path);
+}
+
+fn to_io_network(network: &Network, overrides: &LinkAttributeOverrides) -> IONetwork {
     let mut result = IONetwork::new(None);
 
     for node in network.nodes() {
@@ -45,13 +55,16 @@ pub(crate) fn write_to_xml(network: &Network, path: &Path) {
             .map(|m| m.external().to_string())
             .collect::<Vec<_>>()
             .join(",");
-        let attributes = IOAttributes {
-            attributes: vec![IOAttribute {
-                name: String::from("partition"),
-                value: link.partition.to_string(),
-                class: String::from("java.lang.Integer"),
-            }],
-        };
+        let merged_attributes = merged_link_attributes(link, overrides);
+        let mut attributes = IOAttributes::from(&merged_attributes);
+        attributes
+            .attributes
+            .retain(|attribute| attribute.name != "partition");
+        attributes.attributes.push(IOAttribute {
+            name: String::from("partition"),
+            value: link.partition.to_string(),
+            class: String::from("java.lang.Integer"),
+        });
 
         let io_link = IOLink {
             id: link.id.external().to_string(),
@@ -68,7 +81,7 @@ pub(crate) fn write_to_xml(network: &Network, path: &Path) {
         result.links_mut().push(io_link);
     }
 
-    result.to_file(path);
+    result
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, Clone)]
@@ -187,7 +200,13 @@ mod tests {
 
     use quick_xml::de::from_str;
 
-    use crate::simulation::io::xml::network::IONetwork;
+    use crate::simulation::InternalAttributes;
+    use crate::simulation::id::Id;
+    use crate::simulation::io::xml::network::{IONetwork, to_io_network};
+    use crate::simulation::network::STORAGE_CAPACITY_USED_IN_QSIM;
+    use crate::simulation::scenario::Coordinate;
+    use crate::simulation::scenario::network::{Link, LinkAttributeOverrides, Network, Node};
+    use macros::deterministic_id_test;
 
     static OUTPUT_FOLDER: &str = "./test_output/io/network/";
 
@@ -204,6 +223,51 @@ mod tests {
                 fs::remove_file(entry.unwrap().path()).unwrap();
             }
         }
+    }
+
+    #[deterministic_id_test]
+    fn storage_capacity_attribute_overlay_is_written_to_xml_without_mutating_network() {
+        let mut network = Network::new();
+        let from = Node::new(Id::create("from"), Coordinate::default(), 0, 1);
+        let to = Node::new(Id::create("to"), Coordinate::default(), 0, 1);
+        let link_id = Id::create("link");
+        let link = Link::new_with_default(link_id.clone(), &from, &to);
+        network.add_node(from);
+        network.add_node(to);
+        network.add_link(link);
+
+        let mut link_attributes = InternalAttributes::default();
+        link_attributes.insert(STORAGE_CAPACITY_USED_IN_QSIM, 200.);
+        let mut overrides = LinkAttributeOverrides::default();
+        overrides.insert(link_id.clone(), link_attributes);
+
+        let io_network = to_io_network(&network, &overrides);
+        let attributes = &io_network.links()[0]
+            .attributes
+            .as_ref()
+            .unwrap()
+            .attributes;
+        let storage_attribute = attributes
+            .iter()
+            .find(|attribute| attribute.name == STORAGE_CAPACITY_USED_IN_QSIM)
+            .unwrap();
+
+        assert_eq!("java.lang.Double", storage_attribute.class);
+        assert_eq!("200.0", storage_attribute.value);
+        assert_eq!(
+            1,
+            attributes
+                .iter()
+                .filter(|attribute| attribute.name == "partition")
+                .count()
+        );
+        assert_eq!(
+            None,
+            network
+                .get_link(&link_id)
+                .attributes
+                .get::<f64>(STORAGE_CAPACITY_USED_IN_QSIM)
+        );
     }
 
     #[test]

--- a/rust_qsim/src/simulation/io/xml/population.rs
+++ b/rust_qsim/src/simulation/io/xml/population.rs
@@ -632,7 +632,7 @@ mod tests {
         assert_eq!(Some("person"), attributes.find("subpopulation"));
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn writes_non_default_subpopulation_attribute() {
         let person = InternalPerson::from(IOPerson {
             attributes: Some(IOAttributes {

--- a/rust_qsim/src/simulation/io/xml/population.rs
+++ b/rust_qsim/src/simulation/io/xml/population.rs
@@ -620,7 +620,7 @@ mod tests {
         assert!(!without_score.contains("score="));
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn writes_default_subpopulation_attribute() {
         let population = Population::from_persons(vec![InternalPerson::new(
             Id::create("1"),

--- a/rust_qsim/src/simulation/messaging/sim_communication/message_broker.rs
+++ b/rust_qsim/src/simulation/messaging/sim_communication/message_broker.rs
@@ -162,6 +162,7 @@ mod tests {
     use crate::simulation::id::Id;
     use crate::simulation::messaging::sim_communication::local_communicator::ChannelSimCommunicator;
     use crate::simulation::messaging::sim_communication::message_broker::NetMessageBroker;
+    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::sim_network::SimNetworkPartition;
     use crate::simulation::network::sim_network::StorageUpdate;
     use crate::simulation::scenario::Coordinate;
@@ -358,8 +359,11 @@ mod tests {
             stuck_threshold: 0,
             main_modes: vec![],
         };
+        let network = create_network();
+        let storage_capacities = LinkStorageCapacities::from_network(&network, &config);
         let partition = SimNetworkPartition::from_network(
-            &create_network(),
+            &network,
+            &storage_capacities,
             rank,
             &config,
             config::DEFAULT_RANDOM_SEED,

--- a/rust_qsim/src/simulation/messaging/sim_communication/message_broker.rs
+++ b/rust_qsim/src/simulation/messaging/sim_communication/message_broker.rs
@@ -162,7 +162,6 @@ mod tests {
     use crate::simulation::id::Id;
     use crate::simulation::messaging::sim_communication::local_communicator::ChannelSimCommunicator;
     use crate::simulation::messaging::sim_communication::message_broker::NetMessageBroker;
-    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::sim_network::SimNetworkPartition;
     use crate::simulation::network::sim_network::StorageUpdate;
     use crate::simulation::scenario::Coordinate;
@@ -351,23 +350,15 @@ mod tests {
         communicator: ChannelSimCommunicator,
     ) -> NetMessageBroker<ChannelSimCommunicator> {
         let rank = communicator.rank();
-        let config = config::QSim {
-            start_time: 0,
-            end_time: 0,
-            ticks_per_second: 1,
-            sample_size: 0.0,
-            stuck_threshold: 0,
-            main_modes: vec![],
-        };
+        let mut config = config::Config::default();
+        config.qsim_mut().start_time = 0;
+        config.qsim_mut().end_time = 0;
+        config.qsim_mut().ticks_per_second = 1;
+        config.qsim_mut().sample_size = 0.0;
+        config.qsim_mut().stuck_threshold = 0;
+        config.qsim_mut().main_modes.clear();
         let network = create_network();
-        let storage_capacities = LinkStorageCapacities::from_network(&network, &config);
-        let partition = SimNetworkPartition::from_network(
-            &network,
-            &storage_capacities,
-            rank,
-            &config,
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let partition = SimNetworkPartition::from_network_for_test(&network, rank, &config);
 
         assert_eq!(partition.get_node_ids().len(), 1);
 

--- a/rust_qsim/src/simulation/network/link.rs
+++ b/rust_qsim/src/simulation/network/link.rs
@@ -8,7 +8,6 @@ use crate::simulation::events::{
 use crate::simulation::id::Id;
 use crate::simulation::network::flow_cap::Flowcap;
 use crate::simulation::network::storage_cap::StorageCap;
-use crate::simulation::network::stuck_timer::StuckTimer;
 use crate::simulation::scenario::network::Link;
 use crate::simulation::scenario::network::Node;
 use crate::simulation::time::{SimClock, Tick};
@@ -75,24 +74,12 @@ impl SimLink {
         }
     }
 
-    pub fn offers_veh(&self, now: impl Into<Tick>) -> Option<&SimulationVehicle> {
-        let now = now.into();
+    pub fn offers_veh(&self) -> Option<&SimulationVehicle> {
         match self {
             SimLink::Local(ll) => ll.offers_veh(),
             SimLink::In(il) => il.local_link.offers_veh(),
             SimLink::Out(_) => {
                 panic!("can't query out links to offer vehicles.")
-            }
-        }
-    }
-
-    pub fn is_veh_stuck(&self, now: impl Into<Tick>) -> bool {
-        let now = now.into();
-        match self {
-            SimLink::Local(ll) => ll.stuck_timer.is_stuck(now),
-            SimLink::In(il) => il.local_link.stuck_timer.is_stuck(now),
-            SimLink::Out(_) => {
-                panic!("Out links don't offer vehicles. ")
             }
         }
     }
@@ -143,11 +130,10 @@ impl SimLink {
         }
     }
 
-    pub fn pop_veh(&mut self, now: impl Into<Tick>) -> Option<SimulationVehicle> {
-        let now = now.into();
+    pub fn pop_veh(&mut self) -> Option<SimulationVehicle> {
         match self {
-            SimLink::Local(ll) => ll.pop_veh(now),
-            SimLink::In(il) => il.local_link.pop_veh(now),
+            SimLink::Local(ll) => ll.pop_veh(),
+            SimLink::In(il) => il.local_link.pop_veh(),
             SimLink::Out(_) => {
                 panic!("Can't pop vehicle from out link")
             }
@@ -173,7 +159,6 @@ pub struct LocalLink {
     free_speed: f64,
     storage_cap: StorageCap,
     flow_cap: Flowcap,
-    stuck_timer: StuckTimer,
     clock: SimClock,
     pub from: Id<Node>,
     pub to: Id<Node>,
@@ -211,7 +196,6 @@ impl LocalLink {
             free_speed: 1.0,
             storage_cap: StorageCap::build(0., 1., 1., 1.0, 7.5),
             flow_cap: Flowcap::new(3600., 1.0, 1.0),
-            stuck_timer: StuckTimer::new(Tick::new(u32::MAX as u64)),
             clock,
             from,
             to,
@@ -249,7 +233,6 @@ impl LocalLink {
             free_speed,
             storage_cap,
             flow_cap: Flowcap::new(capacity_h, config.sample_size, capacity_per_tick),
-            stuck_timer: StuckTimer::new(clock.secs_to_tick(config.stuck_threshold as u64)),
             clock,
             from,
             to,
@@ -302,14 +285,8 @@ impl LocalLink {
         let now = now.into();
         let now_time = self.clock.tick_to_time(now);
         self.update_flow_cap(now);
-        let buffer_was_empty = self.buffer.is_empty();
         let mut ending_vehicles = self.add_waiting_to_buffer(comp_env, now);
         ending_vehicles.append(&mut self.add_queue_to_buffer(now));
-
-        if buffer_was_empty && !self.buffer.is_empty() {
-            // In this case, the buffer couldn't be flushed. Thus, a vehicle is stuck and the stuck timer starts.
-            self.stuck_timer.restart(now);
-        }
 
         for v in &ending_vehicles {
             comp_env.events_manager_borrow_mut().process_event(
@@ -437,11 +414,10 @@ impl LocalLink {
     }
 
     /// This method returns the next/first vehicle from the buffer and removes it from the buffer.
-    fn pop_veh(&mut self, now: Tick) -> Option<SimulationVehicle> {
+    fn pop_veh(&mut self) -> Option<SimulationVehicle> {
         if let Some(veh) = self.buffer.pop_front() {
             // self.storage_cap.release(veh.pce);
             self.flow_cap.consume(veh.pce());
-            self.stuck_timer.restart(now);
             return Some(veh);
         }
         None
@@ -485,6 +461,10 @@ impl LocalLink {
     /// A link is active, if either the queue, waiting_list or buffer is not empty.
     pub(super) fn is_active(&self) -> bool {
         !self.q.is_empty() || !self.waiting_list.is_empty() || !self.buffer.is_empty()
+    }
+
+    pub(super) fn buffer_is_empty(&self) -> bool {
+        self.buffer.is_empty()
     }
 
     fn from(&self) -> &Id<Node> {
@@ -579,7 +559,6 @@ impl SplitInLink {
 
 #[cfg(test)]
 mod sim_link_tests {
-    use crate::simulation::config;
     use crate::simulation::id::Id;
     use crate::simulation::network::link::LinkPosition::QStart;
     use crate::simulation::network::link::{LocalLink, SimLink};
@@ -637,7 +616,7 @@ mod sim_link_tests {
         };
 
         l.do_sim_step(1, &mut Default::default());
-        let _vehicle = link.pop_veh(1).unwrap();
+        let _vehicle = link.pop_veh().unwrap();
 
         // After popping, storage is 0.
         assert_eq!(0., link.used_storage());
@@ -672,7 +651,7 @@ mod sim_link_tests {
         l.do_sim_step(10, &mut Default::default());
 
         // this should reduce the flow capacity, so that no other vehicle can leave during this time step
-        let popped1 = l.pop_veh(10.into()).unwrap();
+        let popped1 = l.pop_veh().unwrap();
         assert_eq!("1", popped1.id().external());
 
         // as the flow cap is 0.1/s the next vehicle can leave the link 15s after the first
@@ -682,7 +661,7 @@ mod sim_link_tests {
         }
         l.do_sim_step(25, &mut Default::default());
 
-        if let Some(popped2) = link.offers_veh(25) {
+        if let Some(popped2) = link.offers_veh() {
             assert_eq!("2", popped2.id().external());
         } else {
             panic!("Expected vehicle2 to be available at t=30")
@@ -715,14 +694,14 @@ mod sim_link_tests {
                 unreachable!()
             };
             l.do_sim_step(now, &mut Default::default());
-            assert!(link.offers_veh(now).is_none());
+            assert!(link.offers_veh().is_none());
         }
 
         let SimLink::Local(l) = &mut link else {
             unreachable!()
         };
         l.do_sim_step(10, &mut Default::default());
-        assert!(link.offers_veh(10).is_some())
+        assert!(link.offers_veh().is_some())
     }
 
     #[deterministic_id_test]
@@ -760,128 +739,16 @@ mod sim_link_tests {
         l.do_sim_step(15, &mut Default::default());
 
         // First vehicle pops after 15 s
-        let popped_vehicle1 = l.pop_veh(15.into()).unwrap();
+        let popped_vehicle1 = l.pop_veh().unwrap();
         assert_eq!(id1.to_string(), popped_vehicle1.id().external());
 
         l.do_sim_step(3614, &mut Default::default());
-        assert!(l.pop_veh(3614.into()).is_none());
+        assert!(l.pop_veh().is_none());
 
         // Second vehicle pops after 3615 s
         l.do_sim_step(3615, &mut Default::default());
-        let popped_vehicle2 = link.pop_veh(3615).unwrap();
+        let popped_vehicle2 = link.pop_veh().unwrap();
         assert_eq!(id2.to_string(), popped_vehicle2.id().external());
-    }
-
-    #[deterministic_id_test]
-    pub fn stuck_time() {
-        let stuck_threshold = 10;
-        let config = config::QSim {
-            start_time: 0,
-            end_time: 0,
-            ticks_per_second: 1,
-            sample_size: 1.0,
-            stuck_threshold,
-            main_modes: vec![],
-        };
-        let mut link = SimLink::Local(LocalLink::build(
-            Id::create("stuck-link"),
-            1.,
-            1.,
-            1.0,
-            10.0,
-            7.5,
-            &config,
-            Id::create("from-node"),
-            Id::create("to-node"),
-        ));
-
-        let vehicle = SimulationVehicle::from_parts(1, 0, 10., 1., create_agent_without_route(1));
-        link.push_veh(vehicle, QStart, 0);
-
-        // earliest exit is at 10. Therefore this call should not trigger the stuck timer
-        let SimLink::Local(l) = &mut link else {
-            unreachable!()
-        };
-        l.do_sim_step(9, &mut Default::default());
-        let offers = l.offers_veh();
-        assert!(offers.is_none());
-        assert!(!l.stuck_timer.is_stuck(9));
-
-        // Moving the first vehicle into the empty buffer records the movement time.
-        let expected_timer_start = 10;
-        l.do_sim_step(expected_timer_start, &mut Default::default());
-        let offers = l.offers_veh();
-        assert!(offers.is_some());
-        assert!(
-            !l.stuck_timer
-                .is_stuck(expected_timer_start + stuck_threshold - 1)
-        );
-        assert!(
-            l.stuck_timer
-                .is_stuck(expected_timer_start + stuck_threshold)
-        );
-    }
-
-    #[deterministic_id_test]
-    pub fn stuck_time_reset() {
-        let stuck_threshold = 10;
-        let earliest_exit: u32 = 10;
-        let config = config::QSim {
-            start_time: 0,
-            end_time: 0,
-            ticks_per_second: 1,
-            sample_size: 1.0,
-            stuck_threshold,
-            main_modes: vec![],
-        };
-        let mut link = SimLink::Local(LocalLink::build(
-            Id::create("stuck-link"),
-            36000.,
-            1.,
-            1.0,
-            earliest_exit as f64,
-            7.5,
-            &config,
-            Id::create("from-node"),
-            Id::create("to-node"),
-        ));
-
-        let vehicle1 = SimulationVehicle::from_parts(
-            1,
-            0,
-            earliest_exit as f64,
-            1.,
-            create_agent_without_route(1),
-        );
-        let vehicle2 = SimulationVehicle::from_parts(
-            2,
-            0,
-            earliest_exit as f64,
-            1.,
-            create_agent_without_route(2),
-        );
-        link.push_veh(vehicle1, QStart, 0);
-        link.push_veh(vehicle2, QStart, 0);
-
-        let SimLink::Local(l) = &mut link else {
-            unreachable!()
-        };
-
-        // Moving the first vehicles into the empty buffer records the movement time.
-        l.do_sim_step(earliest_exit, &mut Default::default());
-        assert!(l.offers_veh().is_some());
-        // check that stuck timer works as expected
-        let now = earliest_exit + stuck_threshold;
-        assert!(l.stuck_timer.is_stuck(now));
-        // Fetching the stuck vehicle records the movement time, so the next vehicle is not stuck.
-        let _ = l.pop_veh(now.into());
-        assert!(!l.stuck_timer.is_stuck(now));
-        // the next vehicle should be ready to leave the link as well.
-        // The read-only offer check must not change the movement time.
-        assert!(l.offers_veh().is_some());
-        let now = now + stuck_threshold;
-        assert!(!l.stuck_timer.is_stuck(now - 1));
-        assert!(l.stuck_timer.is_stuck(now));
     }
 }
 

--- a/rust_qsim/src/simulation/network/link.rs
+++ b/rust_qsim/src/simulation/network/link.rs
@@ -7,7 +7,7 @@ use crate::simulation::events::{
 };
 use crate::simulation::id::Id;
 use crate::simulation::network::flow_cap::Flowcap;
-use crate::simulation::network::storage_cap::StorageCap;
+use crate::simulation::network::storage_cap::{StorageCap, StorageCapacityDefinition};
 use crate::simulation::scenario::network::Link;
 use crate::simulation::scenario::network::Node;
 use crate::simulation::time::{SimClock, Tick};
@@ -116,6 +116,15 @@ impl SimLink {
         }
     }
 
+    #[cfg(test)]
+    pub fn max_storage(&self) -> f64 {
+        match self {
+            SimLink::Local(ll) => ll.storage_cap.max(),
+            SimLink::In(il) => il.local_link.storage_cap.max(),
+            SimLink::Out(ol) => ol.storage_cap.max(),
+        }
+    }
+
     pub(super) fn push_veh(
         &mut self,
         vehicle: SimulationVehicle,
@@ -171,37 +180,25 @@ struct VehicleQEntry {
 }
 
 impl LocalLink {
-    pub fn from_link(link: &Link, effective_cell_size: f64, config: &config::QSim) -> Self {
-        LocalLink::build(
+    pub(crate) fn from_link(
+        link: &Link,
+        storage_capacity: &StorageCapacityDefinition,
+        config: &config::QSim,
+    ) -> Self {
+        LocalLink::build_with_storage_capacity(
             link.id.clone(),
             link.capacity,
             link.freespeed,
-            link.permlanes,
             link.length,
-            effective_cell_size,
+            storage_capacity,
             config,
             link.from.clone(),
             link.to.clone(),
         )
     }
 
-    pub fn new_with_defaults(id: Id<Link>, from: Id<Node>, to: Id<Node>) -> Self {
-        let clock = SimClock::new(1);
-        LocalLink {
-            id,
-            q: VecDeque::new(),
-            buffer: VecDeque::new(),
-            waiting_list: VecDeque::new(),
-            length: 1.0,
-            free_speed: 1.0,
-            storage_cap: StorageCap::build(0., 1., 1., 1.0, 7.5),
-            flow_cap: Flowcap::new(3600., 1.0, 1.0),
-            clock,
-            from,
-            to,
-        }
-    }
     #[allow(clippy::too_many_arguments)]
+    #[cfg(test)]
     pub fn build(
         id: Id<Link>,
         capacity_h: f64,
@@ -213,16 +210,41 @@ impl LocalLink {
         from: Id<Node>,
         to: Id<Node>,
     ) -> Self {
-        let clock = SimClock::new(config.ticks_per_second);
-        let capacity_per_tick =
-            (capacity_h * config.sample_size / 3600.) * clock.tick_length().as_secs_f64();
-        let storage_cap = StorageCap::build(
+        let storage_capacity = StorageCapacityDefinition::build(
             length,
             perm_lanes,
             capacity_h,
             config.sample_size,
             effective_cell_size,
+            free_speed,
         );
+        Self::build_with_storage_capacity(
+            id,
+            capacity_h,
+            free_speed,
+            length,
+            &storage_capacity,
+            config,
+            from,
+            to,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn build_with_storage_capacity(
+        id: Id<Link>,
+        capacity_h: f64,
+        free_speed: f64,
+        length: f64,
+        storage_capacity: &StorageCapacityDefinition,
+        config: &config::QSim,
+        from: Id<Node>,
+        to: Id<Node>,
+    ) -> Self {
+        let clock = SimClock::new(config.ticks_per_second);
+        let capacity_per_tick =
+            (capacity_h * config.sample_size / 3600.) * clock.tick_length().as_secs_f64();
+        let storage_cap = StorageCap::from_definition(storage_capacity);
 
         LocalLink {
             id,
@@ -492,19 +514,12 @@ pub struct SplitOutLink {
 }
 
 impl SplitOutLink {
-    pub fn new(
+    pub(crate) fn new(
         link: &Link,
-        effective_cell_size: f64,
-        sample_size: f64,
+        storage_capacity: &StorageCapacityDefinition,
         to_part: u32,
     ) -> SplitOutLink {
-        let storage_cap = StorageCap::build(
-            link.length,
-            link.permlanes,
-            link.capacity,
-            sample_size,
-            effective_cell_size,
-        );
+        let storage_cap = StorageCap::from_definition(storage_capacity);
 
         SplitOutLink {
             id: link.id.clone(),
@@ -769,7 +784,7 @@ mod out_link_tests {
             from: Id::new_internal(0),
             to_part: 1,
             q: Default::default(),
-            storage_cap: StorageCap::build(100., 1., 1., 1., 1.),
+            storage_cap: StorageCap::build(100., 1., 1., 1., 1., 1.),
         });
         let id1 = 42;
         let id2 = 43;
@@ -804,7 +819,7 @@ mod out_link_tests {
     #[deterministic_id_test]
     fn update_storage_caps() {
         // set up the link, so that we consume two units of storage.
-        let mut cap = StorageCap::build(100., 1., 1., 1., 1.);
+        let mut cap = StorageCap::build(100., 1., 1., 1., 1., 1.);
         cap.consume(2.);
         let mut out_link = SplitOutLink {
             id: Id::new_internal(0),

--- a/rust_qsim/src/simulation/network/link.rs
+++ b/rust_qsim/src/simulation/network/link.rs
@@ -8,6 +8,7 @@ use crate::simulation::events::{
 use crate::simulation::id::Id;
 use crate::simulation::network::flow_cap::Flowcap;
 use crate::simulation::network::storage_cap::{StorageCap, StorageCapacityDefinition};
+use crate::simulation::network::stuck_timer::StuckTimer;
 use crate::simulation::scenario::network::Link;
 use crate::simulation::scenario::network::Node;
 use crate::simulation::time::{SimClock, Tick};
@@ -84,6 +85,17 @@ impl SimLink {
         }
     }
 
+    pub(super) fn is_veh_stuck(&self, now: impl Into<Tick>) -> bool {
+        let now = now.into();
+        match self {
+            SimLink::Local(ll) => ll.is_veh_stuck(now),
+            SimLink::In(il) => il.local_link.is_veh_stuck(now),
+            SimLink::Out(_) => {
+                panic!("Out links don't offer vehicles")
+            }
+        }
+    }
+
     pub fn is_available(&self) -> bool {
         match self {
             SimLink::Local(ll) => ll.is_available(),
@@ -139,10 +151,14 @@ impl SimLink {
         }
     }
 
-    pub fn pop_veh(&mut self) -> Option<SimulationVehicle> {
+    pub(super) fn pop_veh_and_restart_stuck_timer(
+        &mut self,
+        now: impl Into<Tick>,
+    ) -> Option<SimulationVehicle> {
+        let now = now.into();
         match self {
-            SimLink::Local(ll) => ll.pop_veh(),
-            SimLink::In(il) => il.local_link.pop_veh(),
+            SimLink::Local(ll) => ll.pop_veh_and_restart_stuck_timer(now),
+            SimLink::In(il) => il.local_link.pop_veh_and_restart_stuck_timer(now),
             SimLink::Out(_) => {
                 panic!("Can't pop vehicle from out link")
             }
@@ -168,6 +184,7 @@ pub struct LocalLink {
     free_speed: f64,
     storage_cap: StorageCap,
     flow_cap: Flowcap,
+    stuck_timer: StuckTimer,
     clock: SimClock,
     pub from: Id<Node>,
     pub to: Id<Node>,
@@ -255,6 +272,7 @@ impl LocalLink {
             free_speed,
             storage_cap,
             flow_cap: Flowcap::new(capacity_h, config.sample_size, capacity_per_tick),
+            stuck_timer: StuckTimer::new(clock.secs_to_tick(config.stuck_threshold as u64)),
             clock,
             from,
             to,
@@ -306,9 +324,13 @@ impl LocalLink {
     ) -> Vec<SimulationVehicle> {
         let now = now.into();
         let now_time = self.clock.tick_to_time(now);
+        let buffer_was_empty = self.buffer.is_empty();
         self.update_flow_cap(now);
         let mut ending_vehicles = self.add_waiting_to_buffer(comp_env, now);
         ending_vehicles.append(&mut self.add_queue_to_buffer(now));
+        if buffer_was_empty && !self.buffer.is_empty() {
+            self.restart_stuck_timer(now);
+        }
 
         for v in &ending_vehicles {
             comp_env.events_manager_borrow_mut().process_event(
@@ -435,14 +457,17 @@ impl LocalLink {
         self.flow_cap.remaining_capacity() - buffer_cap > 0.0
     }
 
-    /// This method returns the next/first vehicle from the buffer and removes it from the buffer.
-    fn pop_veh(&mut self) -> Option<SimulationVehicle> {
+    fn pop_veh_and_restart_stuck_timer(
+        &mut self,
+        now: impl Into<Tick>,
+    ) -> Option<SimulationVehicle> {
         if let Some(veh) = self.buffer.pop_front() {
-            // self.storage_cap.release(veh.pce);
             self.flow_cap.consume(veh.pce());
-            return Some(veh);
+            self.restart_stuck_timer(now);
+            Some(veh)
+        } else {
+            None
         }
-        None
     }
 
     fn update_flow_cap(&mut self, now: Tick) {
@@ -485,8 +510,12 @@ impl LocalLink {
         !self.q.is_empty() || !self.waiting_list.is_empty() || !self.buffer.is_empty()
     }
 
-    pub(super) fn buffer_is_empty(&self) -> bool {
-        self.buffer.is_empty()
+    pub(super) fn is_veh_stuck(&self, now: impl Into<Tick>) -> bool {
+        self.stuck_timer.is_stuck(now)
+    }
+
+    pub(super) fn restart_stuck_timer(&mut self, now: impl Into<Tick>) {
+        self.stuck_timer.restart(now);
     }
 
     fn from(&self) -> &Id<Node> {
@@ -631,7 +660,7 @@ mod sim_link_tests {
         };
 
         l.do_sim_step(1, &mut Default::default());
-        let _vehicle = link.pop_veh().unwrap();
+        let _vehicle = link.pop_veh_and_restart_stuck_timer(1).unwrap();
 
         // After popping, storage is 0.
         assert_eq!(0., link.used_storage());
@@ -666,7 +695,7 @@ mod sim_link_tests {
         l.do_sim_step(10, &mut Default::default());
 
         // this should reduce the flow capacity, so that no other vehicle can leave during this time step
-        let popped1 = l.pop_veh().unwrap();
+        let popped1 = l.pop_veh_and_restart_stuck_timer(10).unwrap();
         assert_eq!("1", popped1.id().external());
 
         // as the flow cap is 0.1/s the next vehicle can leave the link 15s after the first
@@ -720,6 +749,71 @@ mod sim_link_tests {
     }
 
     #[deterministic_id_test]
+    fn stuck_timer_starts_when_vehicle_enters_buffer() {
+        let mut config = test_utils::qsim_config();
+        config.stuck_threshold = 10;
+        let mut link = SimLink::Local(LocalLink::build(
+            Id::create("stuck-link"),
+            3600.,
+            1.,
+            1.,
+            10.,
+            7.5,
+            &config,
+            Id::create("from-node"),
+            Id::create("to-node"),
+        ));
+        let vehicle = SimulationVehicle::from_parts(1, 0, 10., 1., create_agent_without_route(1));
+        link.push_veh(vehicle, QStart, 0);
+
+        let SimLink::Local(local_link) = &mut link else {
+            unreachable!()
+        };
+        local_link.do_sim_step(9, &mut Default::default());
+        assert!(local_link.offers_veh().is_none());
+        assert!(!local_link.is_veh_stuck(100));
+
+        local_link.do_sim_step(10, &mut Default::default());
+        assert!(local_link.offers_veh().is_some());
+        assert!(!local_link.is_veh_stuck(19));
+        assert!(local_link.is_veh_stuck(20));
+    }
+
+    #[deterministic_id_test]
+    fn popping_front_vehicle_restarts_stuck_timer_for_next_vehicle() {
+        let mut config = test_utils::qsim_config();
+        config.stuck_threshold = 10;
+        let mut link = SimLink::Local(LocalLink::build(
+            Id::create("stuck-link"),
+            7200.,
+            1.,
+            1.,
+            1.,
+            7.5,
+            &config,
+            Id::create("from-node"),
+            Id::create("to-node"),
+        ));
+        for id in 1..=2 {
+            let vehicle =
+                SimulationVehicle::from_parts(id, 0, 10., 1., create_agent_without_route(id));
+            link.push_veh(vehicle, QStart, 0);
+        }
+
+        let SimLink::Local(local_link) = &mut link else {
+            unreachable!()
+        };
+        local_link.do_sim_step(1, &mut Default::default());
+        assert!(local_link.offers_veh().is_some());
+
+        let popped = local_link.pop_veh_and_restart_stuck_timer(5).unwrap();
+        assert_eq!("1", popped.id().external());
+        assert!(local_link.offers_veh().is_some());
+        assert!(!local_link.is_veh_stuck(14));
+        assert!(local_link.is_veh_stuck(15));
+    }
+
+    #[deterministic_id_test]
     fn fifo_ordering() {
         let id1 = 42;
         let id2 = 43;
@@ -754,15 +848,15 @@ mod sim_link_tests {
         l.do_sim_step(15, &mut Default::default());
 
         // First vehicle pops after 15 s
-        let popped_vehicle1 = l.pop_veh().unwrap();
+        let popped_vehicle1 = l.pop_veh_and_restart_stuck_timer(15).unwrap();
         assert_eq!(id1.to_string(), popped_vehicle1.id().external());
 
         l.do_sim_step(3614, &mut Default::default());
-        assert!(l.pop_veh().is_none());
+        assert!(l.pop_veh_and_restart_stuck_timer(3614).is_none());
 
         // Second vehicle pops after 3615 s
         l.do_sim_step(3615, &mut Default::default());
-        let popped_vehicle2 = link.pop_veh().unwrap();
+        let popped_vehicle2 = link.pop_veh_and_restart_stuck_timer(3615).unwrap();
         assert_eq!(id2.to_string(), popped_vehicle2.id().external());
     }
 }

--- a/rust_qsim/src/simulation/network/link.rs
+++ b/rust_qsim/src/simulation/network/link.rs
@@ -41,9 +41,7 @@ impl SimLink {
         match self {
             SimLink::Local(l) => l.from(),
             SimLink::In(l) => l.local_link.from(),
-            SimLink::Out(_) => {
-                panic!("There is no from_id of a split out link.")
-            }
+            SimLink::Out(l) => &l.from,
         }
     }
 
@@ -80,8 +78,8 @@ impl SimLink {
     pub fn offers_veh(&self, now: impl Into<Tick>) -> Option<&SimulationVehicle> {
         let now = now.into();
         match self {
-            SimLink::Local(ll) => ll.offers_veh(now),
-            SimLink::In(il) => il.local_link.offers_veh(now),
+            SimLink::Local(ll) => ll.offers_veh(),
+            SimLink::In(il) => il.local_link.offers_veh(),
             SimLink::Out(_) => {
                 panic!("can't query out links to offer vehicles.")
             }
@@ -145,10 +143,11 @@ impl SimLink {
         }
     }
 
-    pub fn pop_veh(&mut self) -> Option<SimulationVehicle> {
+    pub fn pop_veh(&mut self, now: impl Into<Tick>) -> Option<SimulationVehicle> {
+        let now = now.into();
         match self {
-            SimLink::Local(ll) => ll.pop_veh(),
-            SimLink::In(il) => il.local_link.pop_veh(),
+            SimLink::Local(ll) => ll.pop_veh(now),
+            SimLink::In(il) => il.local_link.pop_veh(now),
             SimLink::Out(_) => {
                 panic!("Can't pop vehicle from out link")
             }
@@ -303,8 +302,14 @@ impl LocalLink {
         let now = now.into();
         let now_time = self.clock.tick_to_time(now);
         self.update_flow_cap(now);
+        let buffer_was_empty = self.buffer.is_empty();
         let mut ending_vehicles = self.add_waiting_to_buffer(comp_env, now);
         ending_vehicles.append(&mut self.add_queue_to_buffer(now));
+
+        if buffer_was_empty && !self.buffer.is_empty() {
+            // In this case, the buffer couldn't be flushed. Thus, a vehicle is stuck and the stuck timer starts.
+            self.stuck_timer.restart(now);
+        }
 
         for v in &ending_vehicles {
             comp_env.events_manager_borrow_mut().process_event(
@@ -432,11 +437,11 @@ impl LocalLink {
     }
 
     /// This method returns the next/first vehicle from the buffer and removes it from the buffer.
-    fn pop_veh(&mut self) -> Option<SimulationVehicle> {
+    fn pop_veh(&mut self, now: Tick) -> Option<SimulationVehicle> {
         if let Some(veh) = self.buffer.pop_front() {
             // self.storage_cap.release(veh.pce);
             self.flow_cap.consume(veh.pce());
-            self.stuck_timer.reset();
+            self.stuck_timer.restart(now);
             return Some(veh);
         }
         None
@@ -449,12 +454,10 @@ impl LocalLink {
 
     /// This method returns the next vehicle allowed to leave the connection and checks
     /// whether flow capacity is available.
-    fn offers_veh(&self, now: impl Into<Tick>) -> Option<&SimulationVehicle> {
-        let now = now.into();
+    fn offers_veh(&self) -> Option<&SimulationVehicle> {
         if let Some(entry) = self.buffer.front()
             && self.flow_cap.has_capacity_left()
         {
-            self.stuck_timer.start(now);
             return Some(entry);
         }
 
@@ -492,17 +495,17 @@ impl LocalLink {
         &self.to
     }
 
-    pub fn to_nodes_active(&self, now: impl Into<Tick>) -> bool {
-        let now = now.into();
+    pub fn to_nodes_active(&self) -> bool {
         // the node will only look at the vehicle at the at the top of the queue in the next timestep
         // therefore, peek whether vehicles are available for the next timestep.
-        self.offers_veh(now.next()).is_some()
+        self.offers_veh().is_some()
     }
 }
 
 #[derive(Debug)]
 pub struct SplitOutLink {
     pub id: Id<Link>,
+    from: Id<Node>,
     pub to_part: u32,
     q: VecDeque<SimulationVehicle>,
     storage_cap: StorageCap,
@@ -525,6 +528,7 @@ impl SplitOutLink {
 
         SplitOutLink {
             id: link.id.clone(),
+            from: link.from.clone(),
             to_part,
             q: VecDeque::default(),
             storage_cap,
@@ -633,7 +637,7 @@ mod sim_link_tests {
         };
 
         l.do_sim_step(1, &mut Default::default());
-        let _vehicle = link.pop_veh().unwrap();
+        let _vehicle = link.pop_veh(1).unwrap();
 
         // After popping, storage is 0.
         assert_eq!(0., link.used_storage());
@@ -668,13 +672,13 @@ mod sim_link_tests {
         l.do_sim_step(10, &mut Default::default());
 
         // this should reduce the flow capacity, so that no other vehicle can leave during this time step
-        let popped1 = l.pop_veh().unwrap();
+        let popped1 = l.pop_veh(10.into()).unwrap();
         assert_eq!("1", popped1.id().external());
 
         // as the flow cap is 0.1/s the next vehicle can leave the link 15s after the first
         for now in 11..24 {
             l.do_sim_step(now, &mut Default::default());
-            assert!(l.offers_veh(now).is_none());
+            assert!(l.offers_veh().is_none());
         }
         l.do_sim_step(25, &mut Default::default());
 
@@ -756,15 +760,15 @@ mod sim_link_tests {
         l.do_sim_step(15, &mut Default::default());
 
         // First vehicle pops after 15 s
-        let popped_vehicle1 = l.pop_veh().unwrap();
+        let popped_vehicle1 = l.pop_veh(15.into()).unwrap();
         assert_eq!(id1.to_string(), popped_vehicle1.id().external());
 
         l.do_sim_step(3614, &mut Default::default());
-        assert!(l.pop_veh().is_none());
+        assert!(l.pop_veh(3614.into()).is_none());
 
         // Second vehicle pops after 3615 s
         l.do_sim_step(3615, &mut Default::default());
-        let popped_vehicle2 = link.pop_veh().unwrap();
+        let popped_vehicle2 = link.pop_veh(3615).unwrap();
         assert_eq!(id2.to_string(), popped_vehicle2.id().external());
     }
 
@@ -799,14 +803,14 @@ mod sim_link_tests {
             unreachable!()
         };
         l.do_sim_step(9, &mut Default::default());
-        let offers = l.offers_veh(9);
+        let offers = l.offers_veh();
         assert!(offers.is_none());
         assert!(!l.stuck_timer.is_stuck(9));
 
-        // this should trigger the stuck timer
+        // Moving the first vehicle into the empty buffer records the movement time.
         let expected_timer_start = 10;
         l.do_sim_step(expected_timer_start, &mut Default::default());
-        let offers = l.offers_veh(expected_timer_start);
+        let offers = l.offers_veh();
         assert!(offers.is_some());
         assert!(
             !l.stuck_timer
@@ -863,18 +867,18 @@ mod sim_link_tests {
             unreachable!()
         };
 
-        // trigger stuck timer
+        // Moving the first vehicles into the empty buffer records the movement time.
         l.do_sim_step(earliest_exit, &mut Default::default());
-        assert!(l.offers_veh(earliest_exit).is_some());
+        assert!(l.offers_veh().is_some());
         // check that stuck timer works as expected
         let now = earliest_exit + stuck_threshold;
         assert!(l.stuck_timer.is_stuck(now));
-        // fetch the stuck vehicle, which should reset the timer, so that the next veh is not stuck
-        let _ = l.pop_veh();
+        // Fetching the stuck vehicle records the movement time, so the next vehicle is not stuck.
+        let _ = l.pop_veh(now.into());
         assert!(!l.stuck_timer.is_stuck(now));
         // the next vehicle should be ready to leave the link as well.
-        // This call should trigger the stuck timer again.
-        assert!(l.offers_veh(now).is_some());
+        // The read-only offer check must not change the movement time.
+        assert!(l.offers_veh().is_some());
         let now = now + stuck_threshold;
         assert!(!l.stuck_timer.is_stuck(now - 1));
         assert!(l.stuck_timer.is_stuck(now));
@@ -895,6 +899,7 @@ mod out_link_tests {
     fn push_and_take() {
         let mut link = SimLink::Out(SplitOutLink {
             id: Id::new_internal(0),
+            from: Id::new_internal(0),
             to_part: 1,
             q: Default::default(),
             storage_cap: StorageCap::build(100., 1., 1., 1., 1.),
@@ -936,6 +941,7 @@ mod out_link_tests {
         cap.consume(2.);
         let mut out_link = SplitOutLink {
             id: Id::new_internal(0),
+            from: Id::new_internal(0),
             to_part: 1,
             q: Default::default(),
             storage_cap: cap,

--- a/rust_qsim/src/simulation/network/link.rs
+++ b/rust_qsim/src/simulation/network/link.rs
@@ -592,7 +592,7 @@ mod sim_link_tests {
             3.,
             100.,
             7.5,
-            &test_utils::config(),
+            &test_utils::qsim_config(),
             Id::create("0"),
             Id::create("0"),
         ));
@@ -614,7 +614,7 @@ mod sim_link_tests {
             3.,
             10.,
             7.5,
-            &test_utils::config(),
+            &test_utils::qsim_config(),
             Id::create("0"),
             Id::create("0"),
         ));
@@ -646,7 +646,7 @@ mod sim_link_tests {
             3.,
             100.,
             7.5,
-            &test_utils::config(),
+            &test_utils::qsim_config(),
             Id::create("0"),
             Id::create("0"),
         ));
@@ -692,7 +692,7 @@ mod sim_link_tests {
             3.,
             100.,
             7.5,
-            &test_utils::config(),
+            &test_utils::qsim_config(),
             Id::create("0"),
             Id::create("0"),
         ));
@@ -730,7 +730,7 @@ mod sim_link_tests {
             1.,
             15.0,
             10.0,
-            &test_utils::config(),
+            &test_utils::qsim_config(),
             Id::create("0"),
             Id::create("0"),
         ));

--- a/rust_qsim/src/simulation/network/mod.rs
+++ b/rust_qsim/src/simulation/network/mod.rs
@@ -4,3 +4,6 @@ pub mod metis_partitioning;
 pub mod sim_network;
 mod storage_cap;
 mod stuck_timer;
+
+pub use storage_cap::LinkStorageCapacities;
+pub(crate) const STORAGE_CAPACITY_USED_IN_QSIM: &str = "storageCapacityUsedInQsim";

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -12,7 +12,7 @@ use crate::simulation::vehicles::SimulationVehicle;
 use crate::simulation::{config, random};
 use ahash::AHasher;
 use nohash_hasher::{IntMap, IntSet};
-use rand::Rng;
+use rand::RngExt;
 use rand::rngs::SmallRng;
 use std::cell::RefCell;
 use std::collections::HashSet;

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -499,7 +499,10 @@ impl SimNetworkPartition {
         while !candidates.is_empty() && total_capacity > 1e-10 {
             let rnd_num = rng.random::<f64>() * total_capacity;
             let selected_index = Self::weighted_index(&candidates, rnd_num);
-            let selected = candidates.remove(selected_index);
+
+            // We are using swap remove here on purpose. It has O(1) instead of O(n). Results are still deterministic, but the ordering is not preserved.
+            // This doesn't have any effects on the probabilities, thus it is fine here. paul, jul'26.
+            let selected = candidates.swap_remove(selected_index);
             total_capacity -= selected.weight;
 
             Self::drain_selected_inlink(
@@ -1147,53 +1150,6 @@ mod tests {
         assert_eq!(vec!["3"], events.leaves_on("C"));
         assert!(events.leaves_on("A").is_empty());
         assert!(events.leaves_on("B").is_empty());
-    }
-
-    /// Setting: Two semantically identical three-to-one merges are built with incoming links in A/B/C and C/B/A order respectively, and both use the same seed.
-    /// Execution: Network construction sorts both nodes' incoming links by external ID before the same seeded selection is made.
-    /// Expectation: Both insertion orders select the same incoming link and produce the same LinkLeave event sequence.
-    #[deterministic_id_test]
-    fn inlink_selection_uses_external_id_order() {
-        let node_id = Id::create("K");
-        let mut abc_network = SimNetworkPartition::from_network_for_test(
-            &three_way_merge_network(&["A", "B", "C"]),
-            0,
-            &test_utils::config(),
-        );
-        set_node_rng(&mut abc_network, "K", 0);
-        let first_draw = abc_network
-            .rng
-            .get(&node_id)
-            .unwrap()
-            .clone()
-            .random::<f64>();
-        assert!(
-            first_draw < 1.0 / 3.0 || first_draw > 2.0 / 3.0,
-            "The fixed seed must select an outer third, draw was {first_draw}"
-        );
-
-        let mut cba_network = SimNetworkPartition::from_network_for_test(
-            &three_way_merge_network(&["C", "B", "A"]),
-            0,
-            &test_utils::config(),
-        );
-        set_node_rng(&mut cba_network, "K", 0);
-        for (id, link) in [(1, "A"), (2, "B"), (3, "C")] {
-            abc_network.send_veh_en_route(test_vehicle(id, vec![link, "D"]), None, 0);
-            cba_network.send_veh_en_route(test_vehicle(id, vec![link, "D"]), None, 0);
-        }
-
-        let (mut abc_env, abc_events) = environment_with_transition_events();
-        let (mut cba_env, cba_events) = environment_with_transition_events();
-        abc_network.move_links(&mut abc_env, 0);
-        cba_network.move_links(&mut cba_env, 0);
-        abc_network.move_nodes(&mut abc_env, 1);
-        cba_network.move_nodes(&mut cba_env, 1);
-
-        let expected = if first_draw < 1.0 / 3.0 { "1" } else { "3" };
-        assert_eq!(vec![expected], abc_events.leaving_vehicles());
-        assert_eq!(vec![expected], cba_events.leaving_vehicles());
-        assert_eq!(abc_events.leaving_vehicles(), cba_events.leaving_vehicles());
     }
 
     /// Setting: The weighted candidate intervals are [0, 1] for A and (1, 3] for B.

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -827,22 +827,6 @@ mod tests {
             .insert(Id::create(node), SmallRng::seed_from_u64(seed));
     }
 
-    fn three_way_merge_network(in_link_order: &[&str]) -> Network {
-        let mut network = Network::new();
-        add_test_nodes(&mut network, &["SA", "SB", "SC", "K", "T"]);
-        for id in in_link_order {
-            let from = match *id {
-                "A" => "SA",
-                "B" => "SB",
-                "C" => "SC",
-                _ => panic!("Unexpected in-link id {id}"),
-            };
-            add_test_link(&mut network, id, from, "K", 1.0, 3600.0, 100.0);
-        }
-        add_test_link(&mut network, "D", "K", "T", 7.5, 3600.0, 100.0);
-        network
-    }
-
     /// Setting: A offers A1 with capacity 1, while B offers B1/B2 with capacity 2; the fixed seed selects B first.
     /// Execution: A single node transition drains the selected B buffer before selecting and processing A.
     /// Expectation: The exact LinkLeave order is B1, B2, A1 (vehicle IDs 21, 22, 11).

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -19,6 +19,7 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::hash::Hasher;
 use std::rc::Rc;
+use tracing::warn;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct StorageUpdate {
@@ -523,7 +524,7 @@ impl SimNetworkPartition {
             total_capacity -= selected.weight;
             let stuck_timer = self.stuck_timers.get_mut(selected.id).unwrap();
 
-            let aborted = Self::drain_selected_inlink(
+            Self::drain_selected_inlink(
                 selected.id,
                 &mut self.links,
                 &mut self.active_links,
@@ -532,7 +533,6 @@ impl SimNetworkPartition {
                 self.clock,
                 now,
             );
-            self.veh_counter -= aborted;
         }
 
         // check whether any link is offering next timestep. Otherwise, the node can be de-activated
@@ -585,19 +585,32 @@ impl SimNetworkPartition {
     ) -> FrontDecision {
         let in_link = links.get(in_id).unwrap();
         let Some(vehicle) = in_link.offers_veh() else {
-            // In link empty
             return FrontDecision::NoVehicle;
         };
         let Some(next_id) = vehicle.peek_next_route_element() else {
-            // Vehicle has no next route element
+            warn!(
+                "Vehicle {} offered by link {} has no next route element.",
+                vehicle.id().external(),
+                in_link.id().external()
+            );
             return FrontDecision::Abort;
         };
         let Some(out_link) = links.get(next_id) else {
-            // Next link not found
+            warn!(
+                "Next link {} for vehicle {} offered by link {} is not present in this network partition.",
+                next_id.external(),
+                vehicle.id().external(),
+                in_link.id().external()
+            );
             return FrontDecision::Abort;
         };
         if in_link.to() != out_link.from() {
-            // In link and next link are not connected
+            warn!(
+                "Next link {} for vehicle {} is not connected to in-link {}.",
+                out_link.id().external(),
+                vehicle.id().external(),
+                in_link.id().external()
+            );
             return FrontDecision::Abort;
         }
         if out_link.is_available() {
@@ -617,8 +630,7 @@ impl SimNetworkPartition {
         comp_env: &mut ThreadLocalComputationalEnvironment,
         clock: SimClock,
         now: Tick,
-    ) -> usize {
-        let mut aborted = 0;
+    ) {
         loop {
             match Self::evaluate_front_vehicle(in_link_id, links, stuck_timer, now) {
                 FrontDecision::MoveNormally | FrontDecision::MoveAlthoughStuck => {
@@ -631,14 +643,7 @@ impl SimNetworkPartition {
                     Self::move_vehicle(vehicle, links, active_links, comp_env, clock, now);
                 }
                 FrontDecision::Abort => {
-                    let vehicle = links
-                        .get_mut(in_link_id)
-                        .unwrap()
-                        .pop_veh()
-                        .expect("No vehicle on selected link");
-                    stuck_timer.restart(now);
-                    Self::abort_vehicle(vehicle, comp_env, clock, now);
-                    aborted += 1;
+                    panic!("Invalid turn from in-link {}", in_link_id.external());
                 }
                 FrontDecision::Wait | FrontDecision::NoVehicle => break,
             }
@@ -647,23 +652,6 @@ impl SimNetworkPartition {
         if !links.get(in_link_id).unwrap().is_active() {
             active_links.deactivate(in_link_id);
         }
-        aborted
-    }
-
-    fn abort_vehicle(
-        vehicle: SimulationVehicle,
-        comp_env: &mut ThreadLocalComputationalEnvironment,
-        clock: SimClock,
-        now: Tick,
-    ) {
-        comp_env.events_manager_borrow_mut().process_event(
-            &LinkLeaveEventBuilder::default()
-                .vehicle(vehicle.id().clone())
-                .link(vehicle.curr_link_id().unwrap().clone())
-                .time(clock.tick_to_time(now))
-                .build()
-                .unwrap(),
-        );
     }
 
     /// Moves the vehicle from the current link to the next link.
@@ -747,6 +735,7 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
     use std::cell::RefCell;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::rc::Rc;
 
     #[derive(Clone, Default)]
@@ -1095,10 +1084,10 @@ mod tests {
     }
 
     /// Setting: A vehicle is waiting on A and names `missing`, a link that is not present in the local network, as its next route element.
-    /// Execution: The selected A buffer evaluates the unknown destination as an invalid turn and aborts the vehicle.
-    /// Expectation: The vehicle leaves A without a LinkEnter event or panic, is discarded, and is removed from the network count.
+    /// Execution: The selected A buffer logs the unknown destination and reaches the Abort decision.
+    /// Expectation: Node processing panics before popping the vehicle or emitting a LinkLeave event.
     #[deterministic_id_test]
-    fn missing_next_link_aborts_vehicle() {
+    fn missing_next_link_panics_before_vehicle_is_popped() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["S", "K"]);
         add_test_link(&mut global_network, "A", "S", "K", 1.0, 3600.0, 100.0);
@@ -1113,19 +1102,20 @@ mod tests {
 
         let (mut env, events) = environment_with_transition_events();
         network.move_links(&mut env, 0);
-        network.move_nodes(&mut env, 1);
+        let result = catch_unwind(AssertUnwindSafe(|| network.move_nodes(&mut env, 1)));
 
-        assert_eq!(vec!["1"], events.leaves_on("A"));
+        assert!(result.is_err());
+        assert!(events.leaves_on("A").is_empty());
         assert!(events.link_enters.borrow().is_empty());
-        assert_eq!(0, local_vehicle_count(&network, "A"));
-        assert_eq!(0, network.veh_on_net());
+        assert_eq!(1, local_vehicle_count(&network, "A"));
+        assert_eq!(1, network.veh_on_net());
     }
 
     /// Setting: A ends at K1, while the next route link Z begins at the topologically disconnected node K2; both links belong to the same partition.
-    /// Execution: The selected A buffer compares A's destination node with Z's origin node and aborts the invalid turn.
-    /// Expectation: The vehicle leaves A without entering Z, is discarded, and is removed from the network count.
+    /// Execution: The selected A buffer logs the disconnected destination and reaches the Abort decision.
+    /// Expectation: Node processing panics before popping the vehicle or emitting transition events.
     #[deterministic_id_test]
-    fn disconnected_next_link_aborts_vehicle() {
+    fn disconnected_next_link_panics_before_vehicle_is_popped() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["S", "K1", "K2", "T"]);
         add_test_link(&mut global_network, "A", "S", "K1", 1.0, 3600.0, 100.0);
@@ -1141,13 +1131,14 @@ mod tests {
 
         let (mut env, events) = environment_with_transition_events();
         network.move_links(&mut env, 0);
-        network.move_nodes(&mut env, 1);
+        let result = catch_unwind(AssertUnwindSafe(|| network.move_nodes(&mut env, 1)));
 
-        assert_eq!(vec!["1"], events.leaves_on("A"));
+        assert!(result.is_err());
+        assert!(events.leaves_on("A").is_empty());
         assert!(events.link_enters.borrow().is_empty());
-        assert_eq!(0, local_vehicle_count(&network, "A"));
+        assert_eq!(1, local_vehicle_count(&network, "A"));
         assert_eq!(0, local_vehicle_count(&network, "Z"));
-        assert_eq!(0, network.veh_on_net());
+        assert_eq!(1, network.veh_on_net());
     }
 
     /// Setting: A is active with capacity 100 but does not yet offer a vehicle at tick 1; B and C each offer a vehicle with capacity 1, and D has only one available slot.
@@ -1297,75 +1288,6 @@ mod tests {
             SimNetworkPartition::weighted_index(&candidates, 1.0000001)
         );
         assert_eq!(1, SimNetworkPartition::weighted_index(&candidates, 3.1));
-    }
-
-    /// Setting: A's buffer contains an invalid vehicle targeting an unknown link followed by a valid vehicle targeting X.
-    /// Execution: Draining A aborts and removes the invalid front vehicle, then immediately evaluates the new front vehicle in the same tick.
-    /// Expectation: Both vehicles leave A in FIFO order, only the valid vehicle enters X, and one vehicle remains counted on the network.
-    #[deterministic_id_test]
-    fn aborted_front_vehicle_does_not_block_valid_vehicle_behind_it() {
-        let mut global_network = Network::new();
-        add_test_nodes(&mut global_network, &["S", "K", "T"]);
-        add_test_link(&mut global_network, "A", "S", "K", 1.0, 7200.0, 100.0);
-        add_test_link(&mut global_network, "X", "K", "T", 75.0, 3600.0, 100.0);
-
-        let mut network = SimNetworkPartition::from_network(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
-        network.send_veh_en_route(test_vehicle(1, vec!["A", "missing"]), None, 0);
-        network.send_veh_en_route(test_vehicle(2, vec!["A", "X"]), None, 0);
-
-        let (mut env, events) = environment_with_transition_events();
-        network.move_links(&mut env, 0);
-        network.move_nodes(&mut env, 1);
-
-        assert_eq!(vec!["1", "2"], events.leaves_on("A"));
-        assert_eq!(
-            vec![("X".to_owned(), "2".to_owned())],
-            *events.link_enters.borrow()
-        );
-        assert_eq!(0, local_vehicle_count(&network, "A"));
-        assert_eq!(1, local_vehicle_count(&network, "X"));
-        assert_eq!(1, network.veh_on_net());
-    }
-
-    /// Setting: A contains an invalid front vehicle followed by A2 targeting the full link X, with a stuck threshold of ten ticks.
-    /// Execution: The invalid vehicle is aborted at tick 1, after which A2 remains blocked and is reconsidered at ticks 10 and 11.
-    /// Expectation: The external timer restarts after the abort, so A2 waits at tick 10 and moves at the inclusive threshold at tick 11.
-    #[deterministic_id_test]
-    fn abort_restarts_external_stuck_timer_for_next_front_vehicle() {
-        let mut global_network = Network::new();
-        add_test_nodes(&mut global_network, &["S", "K", "T", "END"]);
-        add_test_link(&mut global_network, "A", "S", "K", 1.0, 7200.0, 100.0);
-        add_test_link(&mut global_network, "X", "K", "T", 7.5, 3600.0, 100.0);
-        add_test_link(&mut global_network, "X2", "T", "END", 7.5, 3600.0, 100.0);
-
-        let mut qsim_config = test_utils::config();
-        qsim_config.stuck_threshold = 10;
-        let mut network = SimNetworkPartition::from_network(
-            &global_network,
-            0,
-            &qsim_config,
-            config::DEFAULT_RANDOM_SEED,
-        );
-        push_vehicle_to_queue(&mut network, "X", 90, vec!["X", "X2"], 0);
-        network.send_veh_en_route(test_vehicle(1, vec!["A", "missing"]), None, 0);
-        network.send_veh_en_route(test_vehicle(2, vec!["A", "X"]), None, 0);
-
-        let (mut env, events) = environment_with_transition_events();
-        network.move_links(&mut env, 0);
-        network.move_nodes(&mut env, 1);
-        assert_eq!(vec!["1"], events.leaves_on("A"));
-
-        network.move_nodes(&mut env, 10);
-        assert_eq!(vec!["1"], events.leaves_on("A"));
-
-        network.move_nodes(&mut env, 11);
-        assert_eq!(vec!["1", "2"], events.leaves_on("A"));
-        assert_eq!(1, network.veh_on_net());
     }
 
     #[deterministic_id_test]

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -7,7 +7,6 @@ use crate::simulation::id::Id;
 use crate::simulation::id::serializable_type::StableTypeId;
 use crate::simulation::network::LinkStorageCapacities;
 use crate::simulation::network::link::LinkPosition::{QStart, Waiting};
-use crate::simulation::network::stuck_timer::StuckTimer;
 use crate::simulation::scenario::network::{Link, Network, Node};
 use crate::simulation::time::{SimClock, Tick};
 use crate::simulation::vehicles::SimulationVehicle;
@@ -82,7 +81,6 @@ pub struct SimNetworkPartition {
     // use int map as hash map variant with stable order
     pub links: IntMap<Id<Link>, SimLink>,
     rng: IntMap<Id<Node>, SmallRng>,
-    stuck_timers: IntMap<Id<Link>, StuckTimer>,
     active_nodes: ActiveCache<Node>,
     active_links: ActiveCache<Link>,
     veh_counter: usize,
@@ -121,7 +119,6 @@ impl SimNetworkPartition {
     ) -> Self {
         let qsim_config = config.qsim();
         let clock = SimClock::new(qsim_config.ticks_per_second);
-        let stuck_threshold = clock.secs_to_tick(qsim_config.stuck_threshold as u64);
         let nodes: Vec<&Node> = global_network
             .nodes()
             .iter()
@@ -162,7 +159,6 @@ impl SimNetworkPartition {
             partition,
             config.computational_setup().random_seed,
             clock,
-            stuck_threshold,
         )
     }
 
@@ -221,7 +217,6 @@ impl SimNetworkPartition {
         partition: u32,
         base_seed: u64,
         clock: SimClock,
-        stuck_threshold: Tick,
     ) -> Self {
         // Initialize RNG with a seed based on the base seed and node id
         let rng = nodes
@@ -233,17 +228,10 @@ impl SimNetworkPartition {
             })
             .collect();
 
-        let stuck_timers = nodes
-            .values()
-            .flat_map(|node| node.in_links.iter())
-            .map(|id| (id.clone(), StuckTimer::new(stuck_threshold)))
-            .collect();
-
         Self {
             nodes,
             links,
             rng,
-            stuck_timers,
             active_links: ActiveCache::<Link>::default(),
             active_nodes: ActiveCache::<Node>::default(),
             veh_counter: 0,
@@ -379,17 +367,12 @@ impl SimNetworkPartition {
         for id in &self.active_links {
             let link = self.links.get_mut(id).unwrap();
             let mut res = match link {
-                SimLink::Local(ll) => Self::move_local_link(
-                    ll,
-                    &mut self.active_nodes,
-                    &mut self.stuck_timers,
-                    now,
-                    comp_env,
-                ),
+                SimLink::Local(ll) => {
+                    Self::move_local_link(ll, &mut self.active_nodes, now, comp_env)
+                }
                 SimLink::In(il) => Self::move_in_link(
                     il,
                     &mut self.active_nodes,
-                    &mut self.stuck_timers,
                     &mut storage_cap_updates,
                     now,
                     comp_env,
@@ -422,15 +405,10 @@ impl SimNetworkPartition {
     fn move_local_link(
         link: &mut LocalLink,
         active_nodes: &mut ActiveCache<Node>,
-        stuck_timers: &mut IntMap<Id<Link>, StuckTimer>,
         now: Tick,
         comp_env: &mut ThreadLocalComputationalEnvironment,
     ) -> MoveSingleLinkResult {
-        let buffer_was_empty = link.buffer_is_empty();
         let vehicles_end_leg = link.do_sim_step(now, comp_env);
-        if buffer_was_empty && !link.buffer_is_empty() {
-            stuck_timers.get_mut(&link.id).unwrap().restart(now);
-        }
         if link.to_nodes_active() {
             active_nodes.activate(link.to.clone());
         }
@@ -447,7 +425,6 @@ impl SimNetworkPartition {
     fn move_in_link(
         link: &mut SplitInLink,
         active_nodes: &mut ActiveCache<Node>,
-        stuck_timers: &mut IntMap<Id<Link>, StuckTimer>,
         storage_cap_updates: &mut Vec<StorageUpdate>,
         now: Tick,
         events: &mut ThreadLocalComputationalEnvironment,
@@ -455,13 +432,7 @@ impl SimNetworkPartition {
         // if anything has changed on the link, we want to report the updated storage capacity to the
         // upstream partition.
         let before = link.occupied_storage();
-        let result = Self::move_local_link(
-            &mut link.local_link,
-            active_nodes,
-            stuck_timers,
-            now,
-            events,
-        );
+        let result = Self::move_local_link(&mut link.local_link, active_nodes, now, events);
         let diff = before - link.occupied_storage();
 
         assert!(
@@ -530,13 +501,11 @@ impl SimNetworkPartition {
             let selected_index = Self::weighted_index(&candidates, rnd_num);
             let selected = candidates.remove(selected_index);
             total_capacity -= selected.weight;
-            let stuck_timer = self.stuck_timers.get_mut(selected.id).unwrap();
 
             Self::drain_selected_inlink(
                 selected.id,
                 &mut self.links,
                 &mut self.active_links,
-                stuck_timer,
                 comp_env,
                 self.clock,
                 now,
@@ -588,7 +557,6 @@ impl SimNetworkPartition {
     fn evaluate_front_vehicle(
         in_id: &Id<Link>,
         links: &IntMap<Id<Link>, SimLink>,
-        stuck_timer: &StuckTimer,
         now: Tick,
     ) -> FrontDecision {
         let in_link = links.get(in_id).unwrap();
@@ -623,7 +591,7 @@ impl SimNetworkPartition {
         }
         if out_link.is_available() {
             FrontDecision::MoveNormally
-        } else if stuck_timer.is_stuck(now) {
+        } else if in_link.is_veh_stuck(now) {
             FrontDecision::MoveAlthoughStuck
         } else {
             FrontDecision::Wait
@@ -634,20 +602,17 @@ impl SimNetworkPartition {
         in_link_id: &Id<Link>,
         links: &mut IntMap<Id<Link>, SimLink>,
         active_links: &mut ActiveCache<Link>,
-        stuck_timer: &mut StuckTimer,
         comp_env: &mut ThreadLocalComputationalEnvironment,
         clock: SimClock,
         now: Tick,
     ) {
         loop {
-            match Self::evaluate_front_vehicle(in_link_id, links, stuck_timer, now) {
+            match Self::evaluate_front_vehicle(in_link_id, links, now) {
                 FrontDecision::MoveNormally | FrontDecision::MoveAlthoughStuck => {
-                    let vehicle = links
-                        .get_mut(in_link_id)
-                        .unwrap()
-                        .pop_veh()
+                    let in_link = links.get_mut(in_link_id).unwrap();
+                    let vehicle = in_link
+                        .pop_veh_and_restart_stuck_timer(now)
                         .expect("No vehicle on selected link");
-                    stuck_timer.restart(now);
                     Self::move_vehicle(vehicle, links, active_links, comp_env, clock, now);
                 }
                 FrontDecision::Abort => {

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -464,7 +464,7 @@ impl SimNetworkPartition {
         // This ensures determinism while maintaining different behavior across time steps
         let (active, mut avail_capacity) =
             Self::get_active_in_links(&node.in_links, &self.active_links, &self.links);
-        let mut exhausted_links: Vec<Option<()>> = vec![None; active.len()];
+        let mut exhausted_links: Vec<bool> = vec![false; active.len()];
         let mut sel_cap: f64 = 0.;
 
         while avail_capacity > 1e-10 {
@@ -476,7 +476,7 @@ impl SimNetworkPartition {
             // go through all in links and fetch one, which is not exhausted yet.
             for i in 0..active.len() {
                 // if the link is exhausted, try next link
-                if exhausted_links[i].is_some() {
+                if exhausted_links[i] {
                     // reduce the available capacity a little bit. Sometimes we have rounding errors
                     // which will cause an infinite loop. Reducing the remaining capacity a little
                     // bit at least prevents infinite loops.
@@ -509,7 +509,7 @@ impl SimNetworkPartition {
                     // in case the vehicle on the link can't move, we add the link to the exhausted
                     // bookkeeping and reduce the available capacity, which makes it more likely for
                     // other links to be able to release vehicles.
-                    exhausted_links[i] = Some(());
+                    exhausted_links[i] = true;
                     let link = self.links.get(link_id).unwrap();
                     avail_capacity -= link.flow_cap();
                 }
@@ -642,6 +642,7 @@ mod tests {
     use crate::simulation::config;
     use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::controller::ThreadLocalComputationalEnvironment;
+    use crate::simulation::events::{LinkEnterEvent, LinkLeaveEvent};
     use crate::simulation::id::Id;
     use crate::simulation::io::xml::events::XmlEventsWriter;
     use crate::simulation::network::link::LinkPosition::QStart;
@@ -653,6 +654,528 @@ mod tests {
     use crate::test_utils;
     use assert_approx_eq::assert_approx_eq;
     use macros::deterministic_id_test;
+    use rand::rngs::SmallRng;
+    use rand::{RngExt, SeedableRng};
+    use std::cell::RefCell;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::rc::Rc;
+
+    #[derive(Clone, Default)]
+    // simple events handler that just records the events it receives.
+    struct TransitionEvents {
+        link_enters: Rc<RefCell<Vec<(String, String)>>>,
+        link_leaves: Rc<RefCell<Vec<(String, String)>>>,
+    }
+
+    impl TransitionEvents {
+        fn register(&self, env: &mut ThreadLocalComputationalEnvironment) {
+            let enters = self.link_enters.clone();
+            env.events_manager_borrow_mut()
+                .on::<LinkEnterEvent, _>(move |event| {
+                    enters.borrow_mut().push((
+                        event.link.external().to_owned(),
+                        event.vehicle.external().to_owned(),
+                    ));
+                });
+
+            let leaves = self.link_leaves.clone();
+            env.events_manager_borrow_mut()
+                .on::<LinkLeaveEvent, _>(move |event| {
+                    leaves.borrow_mut().push((
+                        event.link.external().to_owned(),
+                        event.vehicle.external().to_owned(),
+                    ));
+                });
+        }
+
+        fn leaving_vehicles(&self) -> Vec<String> {
+            self.link_leaves
+                .borrow()
+                .iter()
+                .map(|(_, vehicle)| vehicle.clone())
+                .collect()
+        }
+
+        fn leaves_on(&self, link: &str) -> Vec<String> {
+            self.link_leaves
+                .borrow()
+                .iter()
+                .filter(|(event_link, _)| event_link == link)
+                .map(|(_, vehicle)| vehicle.clone())
+                .collect()
+        }
+    }
+
+    fn environment_with_transition_events()
+    -> (ThreadLocalComputationalEnvironment, TransitionEvents) {
+        let mut env = ThreadLocalComputationalEnvironment::default();
+        let events = TransitionEvents::default();
+        events.register(&mut env);
+        (env, events)
+    }
+
+    fn add_test_nodes(network: &mut Network, ids: &[&str]) {
+        for id in ids {
+            network.add_node(Node::new(Id::create(id), Coordinate::default(), 0, 1));
+        }
+    }
+
+    fn add_test_link(
+        network: &mut Network,
+        id: &str,
+        from: &str,
+        to: &str,
+        length: f64,
+        capacity: f64,
+        freespeed: f64,
+    ) {
+        network.add_link(Link {
+            id: Id::create(id),
+            from: Id::create(from),
+            to: Id::create(to),
+            length,
+            capacity,
+            freespeed,
+            permlanes: 1.0,
+            modes: Default::default(),
+            partition: 0,
+            attributes: Default::default(),
+        });
+    }
+
+    fn test_vehicle(id: u64, route: Vec<&str>) -> SimulationVehicle {
+        SimulationVehicle::from_parts(id, 0, 100.0, 1.0, test_utils::create_agent(id, route))
+    }
+
+    fn push_vehicle_to_queue(
+        network: &mut SimNetworkPartition,
+        link: &str,
+        id: u64,
+        route: Vec<&str>,
+        now: u64,
+    ) {
+        network.links.get_mut(&Id::create(link)).unwrap().push_veh(
+            test_vehicle(id, route),
+            QStart,
+            now,
+        );
+    }
+
+    fn local_vehicle_count(network: &SimNetworkPartition, link: &str) -> usize {
+        match network.links.get(&Id::create(link)).unwrap() {
+            Local(link) => link.veh_count(),
+            _ => panic!("Expected {link} to be a local link"),
+        }
+    }
+
+    fn set_node_rng(network: &mut SimNetworkPartition, node: &str, seed: u64) {
+        network
+            .rng
+            .insert(Id::create(node), SmallRng::seed_from_u64(seed));
+    }
+
+    fn three_way_merge_network(in_link_order: &[&str]) -> Network {
+        let mut network = Network::new();
+        add_test_nodes(&mut network, &["SA", "SB", "SC", "K", "T"]);
+        for id in in_link_order {
+            let from = match *id {
+                "A" => "SA",
+                "B" => "SB",
+                "C" => "SC",
+                _ => panic!("Unexpected in-link id {id}"),
+            };
+            add_test_link(&mut network, id, from, "K", 1.0, 3600.0, 100.0);
+        }
+        add_test_link(&mut network, "D", "K", "T", 7.5, 3600.0, 100.0);
+        network
+    }
+
+    /// Setting: A offers A1 with capacity 1, while B offers B1/B2 with capacity 2; the fixed seed places the first selection in B's capacity interval.
+    /// Execution: A single node transition processes the offered vehicles using the current selection capacity, which accumulates across scans.
+    /// Expectation: The exact LinkLeave order is B1, A1, B2 (vehicle IDs 21, 11, 22).
+    #[deterministic_id_test]
+    fn current_transition_interleaves_selected_buffers() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["SA", "SB", "K", "TX", "TY"]);
+        add_test_link(&mut global_network, "A", "SA", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "B", "SB", "K", 1.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "X", "K", "TX", 75.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "Y", "K", "TY", 75.0, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        set_node_rng(&mut network, "K", 4712);
+        let node_id = Id::create("K");
+        let first_draw = network.rng.get(&node_id).unwrap().clone().random::<f64>();
+        assert!(
+            first_draw > 1.0 / 3.0,
+            "The fixed seed must initially select B, draw was {first_draw}"
+        );
+
+        network.send_veh_en_route(test_vehicle(11, vec!["A", "X"]), None, 0);
+        network.send_veh_en_route(test_vehicle(21, vec!["B", "Y"]), None, 0);
+        network.send_veh_en_route(test_vehicle(22, vec!["B", "Y"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+
+        assert_eq!(vec!["21", "11", "22"], events.leaving_vehicles());
+    }
+
+    /// Setting: A can offer one vehicle per tick and B can offer two; their shared destination link C has storage capacity for exactly two vehicles and is emptied every tick.
+    /// Execution: 100 node transitions run while both incoming links remain supplied.
+    /// Expectation: In the current Rust implementation, exactly one vehicle leaves A and one leaves B per tick, resulting in 100 vehicles from each link.
+    #[deterministic_id_test]
+    fn current_merge_moves_one_vehicle_per_inlink_and_tick() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["SA", "SB", "K", "T"]);
+        add_test_link(&mut global_network, "A", "SA", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "B", "SB", "K", 1.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "C", "K", "T", 15.0, 7200.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        for id in 1..=100 {
+            network.send_veh_en_route(test_vehicle(id, vec!["A", "C"]), None, 0);
+        }
+        for id in 101..=300 {
+            network.send_veh_en_route(test_vehicle(id, vec!["B", "C"]), None, 0);
+        }
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        for now in 1..=100 {
+            network.move_nodes(&mut env, now);
+            network.move_links(&mut env, now);
+        }
+
+        assert_eq!(100, events.leaves_on("A").len());
+        assert_eq!(100, events.leaves_on("B").len());
+        assert_eq!(200, events.link_leaves.borrow().len());
+    }
+
+    /// Setting: A1 wants to enter the already full link X, while B1 independently wants to enter the available link Y.
+    /// Execution: Both incoming links offer a vehicle at the shared node at the same time.
+    /// Expectation: A1 remains on A while B1 leaves B; the blocked turn does not block the entire node.
+    #[deterministic_id_test]
+    fn full_outlink_does_not_block_independent_turn() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["SA", "SB", "K", "TX", "TY", "END"]);
+        add_test_link(&mut global_network, "A", "SA", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "B", "SB", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "X", "K", "TX", 7.5, 3600.0, 100.0);
+        add_test_link(&mut global_network, "Y", "K", "TY", 7.5, 3600.0, 100.0);
+        add_test_link(&mut global_network, "X2", "TX", "END", 7.5, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        push_vehicle_to_queue(&mut network, "X", 90, vec!["X", "X2"], 0);
+        network.send_veh_en_route(test_vehicle(11, vec!["A", "X"]), None, 0);
+        network.send_veh_en_route(test_vehicle(21, vec!["B", "Y"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+
+        assert!(events.leaves_on("A").is_empty());
+        assert_eq!(vec!["21"], events.leaves_on("B"));
+        assert_eq!(1, local_vehicle_count(&network, "A"));
+        assert_eq!(0, local_vehicle_count(&network, "B"));
+    }
+
+    /// Setting: A's FIFO buffer contains A1 targeting X at the front and A2 targeting Y behind it; X is full and Y is available.
+    /// Execution: The node checks the front vehicle A1 but cannot move it onto X.
+    /// Expectation: Neither A1 nor A2 leaves A; the blocked front vehicle blocks the entire incoming buffer for this tick.
+    #[deterministic_id_test]
+    fn blocked_front_vehicle_blocks_vehicles_behind_it() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K", "TX", "TY", "END"]);
+        add_test_link(&mut global_network, "A", "S", "K", 1.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "X", "K", "TX", 7.5, 3600.0, 100.0);
+        add_test_link(&mut global_network, "Y", "K", "TY", 7.5, 3600.0, 100.0);
+        add_test_link(&mut global_network, "X2", "TX", "END", 7.5, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        push_vehicle_to_queue(&mut network, "X", 90, vec!["X", "X2"], 0);
+        network.send_veh_en_route(test_vehicle(11, vec!["A", "X"]), None, 0);
+        network.send_veh_en_route(test_vehicle(12, vec!["A", "Y"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+
+        assert!(events.leaves_on("A").is_empty());
+        assert_eq!(2, local_vehicle_count(&network, "A"));
+        assert_eq!(0, local_vehicle_count(&network, "Y"));
+    }
+
+    /// Setting: C has exactly one available slot, A offers A1 and A2, and the stuck threshold is ten ticks.
+    /// Execution: A1 occupies C's last slot at tick 1, making A2 the blocked front vehicle from tick 1 onward; A2 is checked again at ticks 10 and 11.
+    /// Expectation: A2 remains blocked at tick 10 after waiting nine ticks and leaves A exactly at tick 11 because the current implementation uses an inclusive `>=` comparison.
+    #[deterministic_id_test]
+    fn stuck_vehicle_moves_at_inclusive_threshold() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K", "T", "END"]);
+        add_test_link(&mut global_network, "A", "S", "K", 1.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "C", "K", "T", 15.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "C2", "T", "END", 7.5, 3600.0, 100.0);
+
+        let mut qsim_config = test_utils::config();
+        qsim_config.stuck_threshold = 10;
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &qsim_config,
+            config::DEFAULT_RANDOM_SEED,
+        );
+        push_vehicle_to_queue(&mut network, "C", 90, vec!["C", "C2"], 0);
+        network.send_veh_en_route(test_vehicle(11, vec!["A", "C"]), None, 0);
+        network.send_veh_en_route(test_vehicle(12, vec!["A", "C"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+        assert_eq!(vec!["11"], events.leaves_on("A"));
+
+        network.move_nodes(&mut env, 10);
+        assert_eq!(vec!["11"], events.leaves_on("A"));
+
+        network.move_nodes(&mut env, 11);
+        assert_eq!(vec!["11", "12"], events.leaves_on("A"));
+    }
+
+    /// Setting: The slow link C is 100 m long, has a free speed of 1 m/s, a capacity of 3600 vehicles/h, and already contains 14 vehicles; U offers one additional vehicle for C.
+    /// Execution: The current cell-based storage capacity of about 13.33 is evaluated without the free-speed adjustment, after which the turn from U to C is checked.
+    /// Expectation: C is considered full, U1 does not leave U, and no LinkLeave event is emitted.
+    #[deterministic_id_test]
+    fn slow_link_uses_current_cell_based_storage_capacity() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K", "T", "END"]);
+        add_test_link(&mut global_network, "U", "S", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "C", "K", "T", 100.0, 3600.0, 1.0);
+        add_test_link(&mut global_network, "C2", "T", "END", 7.5, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        for id in 100..114 {
+            push_vehicle_to_queue(&mut network, "C", id, vec!["C", "C2"], 0);
+        }
+        network.send_veh_en_route(test_vehicle(1, vec!["U", "C"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        assert_eq!(
+            14.0,
+            network.links.get(&Id::create("C")).unwrap().used_storage()
+        );
+        assert!(!network.links.get(&Id::create("C")).unwrap().is_available());
+
+        network.move_nodes(&mut env, 1);
+        assert!(events.leaves_on("U").is_empty());
+        assert_eq!(1, local_vehicle_count(&network, "U"));
+    }
+
+    /// Setting: A vehicle is waiting on A and names `missing`, a link that is not present in the local network, as its next route element.
+    /// Execution: The node attempts to resolve the unknown destination link in `should_veh_move_out`.
+    /// Expectation: The current implementation panics before moving the vehicle; it remains on A and no LinkLeave event is emitted.
+    #[deterministic_id_test]
+    fn missing_next_link_panics_before_link_leave() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K"]);
+        add_test_link(&mut global_network, "A", "S", "K", 1.0, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        network.send_veh_en_route(test_vehicle(1, vec!["A", "missing"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        let result = catch_unwind(AssertUnwindSafe(|| network.move_nodes(&mut env, 1)));
+
+        assert!(result.is_err());
+        assert!(events.link_leaves.borrow().is_empty());
+        assert_eq!(1, local_vehicle_count(&network, "A"));
+    }
+
+    /// Setting: A ends at K1, while the next route link Z begins at the topologically disconnected node K2; both links belong to the same partition.
+    /// Execution: The vehicle is processed at K1 without validating the connection from A to Z.
+    /// Expectation: The current implementation accepts the turn, emits LinkLeave(A) and LinkEnter(Z), and places the vehicle directly on Z.
+    #[deterministic_id_test]
+    fn disconnected_next_link_is_accepted() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K1", "K2", "T"]);
+        add_test_link(&mut global_network, "A", "S", "K1", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "Z", "K2", "T", 75.0, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        network.send_veh_en_route(test_vehicle(1, vec!["A", "Z"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+
+        assert_eq!(vec!["1"], events.leaves_on("A"));
+        assert_eq!(
+            vec![("Z".to_owned(), "1".to_owned())],
+            *events.link_enters.borrow()
+        );
+        assert_eq!(0, local_vehicle_count(&network, "A"));
+        assert_eq!(1, local_vehicle_count(&network, "Z"));
+    }
+
+    /// Setting: A is active with capacity 100 but does not yet offer a vehicle at tick 1; B and C each offer a vehicle with capacity 1, and D has only one available slot.
+    /// Execution: A is nevertheless included with B and C in the candidate set and the total capacity of 102; the fixed seed makes the first scan select no vehicle.
+    /// Expectation: The current transition consumes three RNG draws, then moves only B's vehicle and emits no LinkLeave event for A or C.
+    #[deterministic_id_test]
+    fn non_offering_active_link_is_currently_a_candidate() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["SA", "SB", "SC", "K", "TA", "T"]);
+        add_test_link(&mut global_network, "A", "SA", "K", 100.0, 360000.0, 1.0);
+        add_test_link(&mut global_network, "B", "SB", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "C", "SC", "K", 1.0, 3600.0, 100.0);
+        add_test_link(&mut global_network, "D", "K", "T", 7.5, 3600.0, 100.0);
+        add_test_link(&mut global_network, "A2", "K", "TA", 7.5, 3600.0, 100.0);
+
+        let base_seed = config::DEFAULT_RANDOM_SEED;
+        let mut network =
+            SimNetworkPartition::from_network(&global_network, 0, &test_utils::config(), base_seed);
+        set_node_rng(&mut network, "K", 4711);
+        let slow_vehicle = SimulationVehicle::from_parts(
+            1,
+            0,
+            1.0,
+            1.0,
+            test_utils::create_agent(1, vec!["A", "A2"]),
+        );
+        network
+            .links
+            .get_mut(&Id::create("A"))
+            .unwrap()
+            .push_veh(slow_vehicle, QStart, 0);
+        network.active_links.activate(Id::create("A"));
+        network.veh_counter += 1;
+        network.send_veh_en_route(test_vehicle(2, vec!["B", "D"]), None, 0);
+        network.send_veh_en_route(test_vehicle(3, vec!["C", "D"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        let node_id = Id::create("K");
+        let (active, capacity) = {
+            let node = network.nodes.get(&node_id).unwrap();
+            SimNetworkPartition::get_active_in_links(
+                &node.in_links,
+                &network.active_links,
+                &network.links,
+            )
+        };
+        assert_eq!(
+            vec![Id::create("A"), Id::create("B"), Id::create("C")],
+            active
+        );
+        assert_eq!(102.0, capacity);
+
+        let mut expected_rng = network.rng.get(&node_id).unwrap().clone();
+        let first_draw = expected_rng.random::<f64>();
+        assert!(
+            first_draw > 2.0 / 102.0,
+            "The first draw must miss B and C when A contributes capacity: {first_draw}"
+        );
+        expected_rng.random::<f64>();
+        expected_rng.random::<f64>();
+        let fourth_draw = expected_rng.random::<u64>();
+
+        // move nodes calls 3 times the rng: Choose A, mark it as exhausted; choose B, move vehicle & mark it as exhausted; choose C, but D is blocked, so mark it as exhausted.
+        network.move_nodes(&mut env, 1);
+        let actual_fourth_draw = network.rng.get_mut(&node_id).unwrap().random::<u64>();
+
+        // check if move nodes consumed 3 draws and produces the same fourth draw as expected
+        assert_eq!(fourth_draw, actual_fourth_draw);
+        assert_eq!(vec!["2"], events.leaves_on("B"));
+        assert!(events.leaves_on("A").is_empty());
+        assert!(events.leaves_on("C").is_empty());
+    }
+
+    /// Setting: Two semantically identical three-to-one merges are built with incoming links in A/B/C and C/B/A order respectively, and both use the same seed.
+    /// Execution: One vehicle from each incoming link competes for D's single available slot; the seed deliberately falls within an outer third of the selection distribution.
+    /// Expectation: Because the current implementation iterates in insertion order, mirrored incoming links—and therefore different vehicles—win in the two networks.
+    #[deterministic_id_test]
+    fn inlink_iteration_follows_network_insertion_order() {
+        let base_seed = config::DEFAULT_RANDOM_SEED;
+        let node_id = Id::create("K");
+        let mut abc_network = SimNetworkPartition::from_network(
+            &three_way_merge_network(&["A", "B", "C"]),
+            0,
+            &test_utils::config(),
+            base_seed,
+        );
+        set_node_rng(&mut abc_network, "K", 0);
+        let first_draw = abc_network
+            .rng
+            .get(&node_id)
+            .unwrap()
+            .clone()
+            .random::<f64>();
+        assert!(
+            first_draw < 1.0 / 3.0 || first_draw > 2.0 / 3.0,
+            "The fixed seed must select an outer third, draw was {first_draw}"
+        );
+
+        let mut cba_network = SimNetworkPartition::from_network(
+            &three_way_merge_network(&["C", "B", "A"]),
+            0,
+            &test_utils::config(),
+            base_seed,
+        );
+        set_node_rng(&mut cba_network, "K", 0);
+        for (id, link) in [(1, "A"), (2, "B"), (3, "C")] {
+            abc_network.send_veh_en_route(test_vehicle(id, vec![link, "D"]), None, 0);
+            cba_network.send_veh_en_route(test_vehicle(id, vec![link, "D"]), None, 0);
+        }
+
+        let (mut abc_env, abc_events) = environment_with_transition_events();
+        let (mut cba_env, cba_events) = environment_with_transition_events();
+        abc_network.move_links(&mut abc_env, 0);
+        cba_network.move_links(&mut cba_env, 0);
+        abc_network.move_nodes(&mut abc_env, 1);
+        cba_network.move_nodes(&mut cba_env, 1);
+
+        let expected_abc = if first_draw < 1.0 / 3.0 { "1" } else { "3" };
+        let expected_cba = if first_draw < 1.0 / 3.0 { "3" } else { "1" };
+        assert_eq!(vec![expected_abc], abc_events.leaving_vehicles());
+        assert_eq!(vec![expected_cba], cba_events.leaving_vehicles());
+        assert_ne!(abc_events.leaving_vehicles(), cba_events.leaving_vehicles());
+    }
 
     #[deterministic_id_test]
     fn from_network() {

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -6,6 +6,7 @@ use crate::simulation::events::{EventsManager, LinkEnterEventBuilder, LinkLeaveE
 use crate::simulation::id::Id;
 use crate::simulation::id::serializable_type::StableTypeId;
 use crate::simulation::network::link::LinkPosition::{QStart, Waiting};
+use crate::simulation::network::stuck_timer::StuckTimer;
 use crate::simulation::scenario::network::{Link, Network, Node};
 use crate::simulation::time::{SimClock, Tick};
 use crate::simulation::vehicles::SimulationVehicle;
@@ -79,6 +80,7 @@ pub struct SimNetworkPartition {
     // use int map as hash map variant with stable order
     pub links: IntMap<Id<Link>, SimLink>,
     rng: IntMap<Id<Node>, SmallRng>,
+    stuck_timers: IntMap<Id<Link>, StuckTimer>,
     active_nodes: ActiveCache<Node>,
     active_links: ActiveCache<Link>,
     veh_counter: usize,
@@ -116,6 +118,7 @@ impl SimNetworkPartition {
         base_seed: u64,
     ) -> Self {
         let clock = SimClock::new(config.ticks_per_second);
+        let stuck_threshold = clock.secs_to_tick(config.stuck_threshold as u64);
         let nodes: Vec<&Node> = global_network
             .nodes()
             .iter()
@@ -150,7 +153,14 @@ impl SimNetworkPartition {
             .map(|n| (n.id.clone(), Self::create_sim_node(n)))
             .collect();
 
-        SimNetworkPartition::build(sim_nodes, sim_links, partition, base_seed, clock)
+        SimNetworkPartition::build(
+            sim_nodes,
+            sim_links,
+            partition,
+            base_seed,
+            clock,
+            stuck_threshold,
+        )
     }
 
     pub(crate) fn drain(&mut self) -> Vec<SimulationAgent> {
@@ -202,6 +212,7 @@ impl SimNetworkPartition {
         partition: u32,
         base_seed: u64,
         clock: SimClock,
+        stuck_threshold: Tick,
     ) -> Self {
         // Initialize RNG with a seed based on the base seed and node id
         let rng = nodes
@@ -213,10 +224,17 @@ impl SimNetworkPartition {
             })
             .collect();
 
+        let stuck_timers = nodes
+            .values()
+            .flat_map(|node| node.in_links.iter())
+            .map(|id| (id.clone(), StuckTimer::new(stuck_threshold)))
+            .collect();
+
         Self {
             nodes,
             links,
             rng,
+            stuck_timers,
             active_links: ActiveCache::<Link>::default(),
             active_nodes: ActiveCache::<Node>::default(),
             veh_counter: 0,
@@ -352,12 +370,17 @@ impl SimNetworkPartition {
         for id in &self.active_links {
             let link = self.links.get_mut(id).unwrap();
             let mut res = match link {
-                SimLink::Local(ll) => {
-                    Self::move_local_link(ll, &mut self.active_nodes, now, comp_env)
-                }
+                SimLink::Local(ll) => Self::move_local_link(
+                    ll,
+                    &mut self.active_nodes,
+                    &mut self.stuck_timers,
+                    now,
+                    comp_env,
+                ),
                 SimLink::In(il) => Self::move_in_link(
                     il,
                     &mut self.active_nodes,
+                    &mut self.stuck_timers,
                     &mut storage_cap_updates,
                     now,
                     comp_env,
@@ -390,10 +413,15 @@ impl SimNetworkPartition {
     fn move_local_link(
         link: &mut LocalLink,
         active_nodes: &mut ActiveCache<Node>,
+        stuck_timers: &mut IntMap<Id<Link>, StuckTimer>,
         now: Tick,
         comp_env: &mut ThreadLocalComputationalEnvironment,
     ) -> MoveSingleLinkResult {
+        let buffer_was_empty = link.buffer_is_empty();
         let vehicles_end_leg = link.do_sim_step(now, comp_env);
+        if buffer_was_empty && !link.buffer_is_empty() {
+            stuck_timers.get_mut(&link.id).unwrap().restart(now);
+        }
         if link.to_nodes_active() {
             active_nodes.activate(link.to.clone());
         }
@@ -410,6 +438,7 @@ impl SimNetworkPartition {
     fn move_in_link(
         link: &mut SplitInLink,
         active_nodes: &mut ActiveCache<Node>,
+        stuck_timers: &mut IntMap<Id<Link>, StuckTimer>,
         storage_cap_updates: &mut Vec<StorageUpdate>,
         now: Tick,
         events: &mut ThreadLocalComputationalEnvironment,
@@ -417,7 +446,13 @@ impl SimNetworkPartition {
         // if anything has changed on the link, we want to report the updated storage capacity to the
         // upstream partition.
         let before = link.occupied_storage();
-        let result = Self::move_local_link(&mut link.local_link, active_nodes, now, events);
+        let result = Self::move_local_link(
+            &mut link.local_link,
+            active_nodes,
+            stuck_timers,
+            now,
+            events,
+        );
         let diff = before - link.occupied_storage();
 
         assert!(
@@ -478,7 +513,7 @@ impl SimNetworkPartition {
     ) -> bool {
         let node = self.nodes.get(node_id).unwrap();
         let (mut candidates, mut total_capacity) =
-            Self::get_candidates(&node.in_links, &self.links, now);
+            Self::get_candidates(&node.in_links, &self.links);
         let rng = self.rng.get_mut(node_id).unwrap();
 
         while !candidates.is_empty() && total_capacity > 1e-10 {
@@ -486,11 +521,13 @@ impl SimNetworkPartition {
             let selected_index = Self::weighted_index(&candidates, rnd_num);
             let selected = candidates.remove(selected_index);
             total_capacity -= selected.weight;
+            let stuck_timer = self.stuck_timers.get_mut(selected.id).unwrap();
 
             let aborted = Self::drain_selected_inlink(
                 selected.id,
                 &mut self.links,
                 &mut self.active_links,
+                stuck_timer,
                 comp_env,
                 self.clock,
                 now,
@@ -498,21 +535,20 @@ impl SimNetworkPartition {
             self.veh_counter -= aborted;
         }
 
-        // check whether any link is offering next timestep. Otherwise the node can be de-activated
-        Self::any_link_offers(&node.in_links, &self.links, now.next())
+        // check whether any link is offering next timestep. Otherwise, the node can be de-activated
+        Self::any_link_offers(&node.in_links, &self.links)
     }
 
     fn get_candidates<'a>(
         in_links: &'a [Id<Link>],
         links: &IntMap<Id<Link>, SimLink>,
-        now: Tick,
     ) -> (Vec<Candidate<'a>>, f64) {
         let mut candidates = Vec::with_capacity(in_links.len());
         let mut total_capacity = 0.;
 
         for id in in_links {
             let link = links.get(id).unwrap();
-            if link.offers_veh(now).is_some() {
+            if link.offers_veh().is_some() {
                 let weight = link.flow_cap();
                 candidates.push(Candidate { id, weight });
                 total_capacity += weight;
@@ -534,38 +570,39 @@ impl SimNetworkPartition {
         candidates.len() - 1
     }
 
-    fn any_link_offers(
-        link_ids: &[Id<Link>],
-        links: &IntMap<Id<Link>, SimLink>,
-        time: Tick,
-    ) -> bool {
+    fn any_link_offers(link_ids: &[Id<Link>], links: &IntMap<Id<Link>, SimLink>) -> bool {
         link_ids
             .iter()
             .map(|id| links.get(id).unwrap())
-            .any(|link| link.offers_veh(time).is_some())
+            .any(|link| link.offers_veh().is_some())
     }
 
     fn evaluate_front_vehicle(
         in_id: &Id<Link>,
         links: &IntMap<Id<Link>, SimLink>,
+        stuck_timer: &StuckTimer,
         now: Tick,
     ) -> FrontDecision {
         let in_link = links.get(in_id).unwrap();
-        let Some(vehicle) = in_link.offers_veh(now) else {
+        let Some(vehicle) = in_link.offers_veh() else {
+            // In link empty
             return FrontDecision::NoVehicle;
         };
         let Some(next_id) = vehicle.peek_next_route_element() else {
+            // Vehicle has no next route element
             return FrontDecision::Abort;
         };
         let Some(out_link) = links.get(next_id) else {
+            // Next link not found
             return FrontDecision::Abort;
         };
         if in_link.to() != out_link.from() {
+            // In link and next link are not connected
             return FrontDecision::Abort;
         }
         if out_link.is_available() {
             FrontDecision::MoveNormally
-        } else if in_link.is_veh_stuck(now) {
+        } else if stuck_timer.is_stuck(now) {
             FrontDecision::MoveAlthoughStuck
         } else {
             FrontDecision::Wait
@@ -576,27 +613,30 @@ impl SimNetworkPartition {
         in_link_id: &Id<Link>,
         links: &mut IntMap<Id<Link>, SimLink>,
         active_links: &mut ActiveCache<Link>,
+        stuck_timer: &mut StuckTimer,
         comp_env: &mut ThreadLocalComputationalEnvironment,
         clock: SimClock,
         now: Tick,
     ) -> usize {
         let mut aborted = 0;
         loop {
-            match Self::evaluate_front_vehicle(in_link_id, links, now) {
+            match Self::evaluate_front_vehicle(in_link_id, links, stuck_timer, now) {
                 FrontDecision::MoveNormally | FrontDecision::MoveAlthoughStuck => {
                     let vehicle = links
                         .get_mut(in_link_id)
                         .unwrap()
-                        .pop_veh(now)
+                        .pop_veh()
                         .expect("No vehicle on selected link");
+                    stuck_timer.restart(now);
                     Self::move_vehicle(vehicle, links, active_links, comp_env, clock, now);
                 }
                 FrontDecision::Abort => {
                     let vehicle = links
                         .get_mut(in_link_id)
                         .unwrap()
-                        .pop_veh(now)
+                        .pop_veh()
                         .expect("No vehicle on selected link");
+                    stuck_timer.restart(now);
                     Self::abort_vehicle(vehicle, comp_env, clock, now);
                     aborted += 1;
                 }
@@ -1149,7 +1189,7 @@ mod tests {
         let node_id = Id::create("K");
         let (candidates, capacity) = {
             let node = network.nodes.get(&node_id).unwrap();
-            SimNetworkPartition::get_candidates(&node.in_links, &network.links, 1.into())
+            SimNetworkPartition::get_candidates(&node.in_links, &network.links)
         };
         assert_eq!(
             vec!["B", "C"],
@@ -1289,6 +1329,42 @@ mod tests {
         );
         assert_eq!(0, local_vehicle_count(&network, "A"));
         assert_eq!(1, local_vehicle_count(&network, "X"));
+        assert_eq!(1, network.veh_on_net());
+    }
+
+    /// Setting: A contains an invalid front vehicle followed by A2 targeting the full link X, with a stuck threshold of ten ticks.
+    /// Execution: The invalid vehicle is aborted at tick 1, after which A2 remains blocked and is reconsidered at ticks 10 and 11.
+    /// Expectation: The external timer restarts after the abort, so A2 waits at tick 10 and moves at the inclusive threshold at tick 11.
+    #[deterministic_id_test]
+    fn abort_restarts_external_stuck_timer_for_next_front_vehicle() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K", "T", "END"]);
+        add_test_link(&mut global_network, "A", "S", "K", 1.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "X", "K", "T", 7.5, 3600.0, 100.0);
+        add_test_link(&mut global_network, "X2", "T", "END", 7.5, 3600.0, 100.0);
+
+        let mut qsim_config = test_utils::config();
+        qsim_config.stuck_threshold = 10;
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &qsim_config,
+            config::DEFAULT_RANDOM_SEED,
+        );
+        push_vehicle_to_queue(&mut network, "X", 90, vec!["X", "X2"], 0);
+        network.send_veh_en_route(test_vehicle(1, vec!["A", "missing"]), None, 0);
+        network.send_veh_en_route(test_vehicle(2, vec!["A", "X"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+        assert_eq!(vec!["1"], events.leaves_on("A"));
+
+        network.move_nodes(&mut env, 10);
+        assert_eq!(vec!["1"], events.leaves_on("A"));
+
+        network.move_nodes(&mut env, 11);
+        assert_eq!(vec!["1", "2"], events.leaves_on("A"));
         assert_eq!(1, network.veh_on_net());
     }
 
@@ -1484,12 +1560,12 @@ mod tests {
             // at 10, 20, 30, ... link1 offers a vehicle
             if now < 91 && (0..91).step_by(10).collect::<Vec<u32>>().contains(&now) {
                 assert!(
-                    link1.offers_veh(now).is_some(),
+                    link1.offers_veh().is_some(),
                     "No vehicle offered at timestep {now}"
                 );
             } else {
                 assert!(
-                    link1.offers_veh(now).is_none(),
+                    link1.offers_veh().is_none(),
                     "Vehicle offered at timestep {now}"
                 );
             }
@@ -1497,7 +1573,7 @@ mod tests {
             // From 1002, no vehicle if offered by link1
             if (1002..1911).contains(&now) {
                 // once the last vehicle has moved, link1 has nothing to offer.
-                assert!(link1.offers_veh(now).is_none());
+                assert!(link1.offers_veh().is_none());
 
                 // veh0 reaches buffer at 1001 and is released immediately.
                 // veh1 reaches buffer at 1011 and is released at 1102; flow cap is refilled after 10
@@ -1514,7 +1590,7 @@ mod tests {
                     || (1819..=1910).contains(&now)
                 {
                     assert!(
-                        link2.offers_veh(now).is_some(),
+                        link2.offers_veh().is_some(),
                         "No vehicle offered at timestep {now}"
                     );
                     if !(now == 1102
@@ -1534,7 +1610,7 @@ mod tests {
                     }
                 } else {
                     assert!(
-                        link2.offers_veh(now).is_none(),
+                        link2.offers_veh().is_none(),
                         "Vehicle offered at timestep {now}"
                     );
                 }
@@ -1585,12 +1661,12 @@ mod tests {
             // at 10, 20, 30, ... link1 offers a vehicle
             if now < 91 && (0..91).step_by(10).collect::<Vec<u32>>().contains(&now) {
                 assert!(
-                    link1.offers_veh(now).is_some(),
+                    link1.offers_veh().is_some(),
                     "No vehicle offered at timestep {now}"
                 );
             } else {
                 assert!(
-                    link1.offers_veh(now).is_none(),
+                    link1.offers_veh().is_none(),
                     "Vehicle offered at timestep {now}"
                 );
             }
@@ -1598,7 +1674,7 @@ mod tests {
             // From 1002, no vehicle if offered by link1
             if (1002..1911).contains(&now) {
                 // once the last vehicle has moved, link1 has nothing to offer.
-                assert!(link1.offers_veh(now).is_none());
+                assert!(link1.offers_veh().is_none());
 
                 // veh0 reaches buffer at 1001 and is released immediately.
                 // veh1 reaches the buffer at 1011 and is released at 1021.
@@ -1616,7 +1692,7 @@ mod tests {
                     || (1163..1173).contains(&now)
                 {
                     assert!(
-                        link2.offers_veh(now).is_some(),
+                        link2.offers_veh().is_some(),
                         "No vehicle offered at timestep {now}"
                     );
                     assert!(
@@ -1625,7 +1701,7 @@ mod tests {
                     );
                 } else {
                     assert!(
-                        link2.offers_veh(now).is_none(),
+                        link2.offers_veh().is_none(),
                         "Vehicle offered at timestep {now}"
                     );
                 }

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -117,11 +117,11 @@ impl SimNetworkPartition {
         global_network: &Network,
         storage_capacities: &LinkStorageCapacities,
         partition: u32,
-        config: &config::QSim,
-        base_seed: u64,
+        config: &config::Config,
     ) -> Self {
-        let clock = SimClock::new(config.ticks_per_second);
-        let stuck_threshold = clock.secs_to_tick(config.stuck_threshold as u64);
+        let qsim_config = config.qsim();
+        let clock = SimClock::new(qsim_config.ticks_per_second);
+        let stuck_threshold = clock.secs_to_tick(qsim_config.stuck_threshold as u64);
         let nodes: Vec<&Node> = global_network
             .nodes()
             .iter()
@@ -144,7 +144,7 @@ impl SimNetworkPartition {
                         link,
                         storage_capacities,
                         partition,
-                        config,
+                        qsim_config,
                         global_network,
                     ),
                 )
@@ -160,10 +160,20 @@ impl SimNetworkPartition {
             sim_nodes,
             sim_links,
             partition,
-            base_seed,
+            config.computational_setup().random_seed,
             clock,
             stuck_threshold,
         )
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_network_for_test(
+        global_network: &Network,
+        partition: u32,
+        config: &config::Config,
+    ) -> Self {
+        let storage_capacities = LinkStorageCapacities::from_network(global_network, config.qsim());
+        Self::from_network(global_network, &storage_capacities, partition, config)
     }
 
     pub(crate) fn drain(&mut self) -> Vec<SimulationAgent> {
@@ -715,13 +725,11 @@ struct MoveSingleLinkResult {
 #[cfg(test)]
 mod tests {
     use super::{Candidate, SimNetworkPartition};
-    use crate::simulation::config;
     use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::controller::ThreadLocalComputationalEnvironment;
     use crate::simulation::events::{LinkEnterEvent, LinkLeaveEvent};
     use crate::simulation::id::Id;
     use crate::simulation::io::xml::events::XmlEventsWriter;
-    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::link::LinkPosition::QStart;
     use crate::simulation::network::link::SimLink;
     use crate::simulation::network::link::SimLink::Local;
@@ -736,22 +744,6 @@ mod tests {
     use std::cell::RefCell;
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::rc::Rc;
-
-    fn test_network_partition(
-        network: &Network,
-        partition: u32,
-        config: &config::QSim,
-        base_seed: u64,
-    ) -> SimNetworkPartition {
-        let storage_capacities = LinkStorageCapacities::from_network(network, config);
-        SimNetworkPartition::from_network(
-            network,
-            &storage_capacities,
-            partition,
-            config,
-            base_seed,
-        )
-    }
 
     #[derive(Clone, Default)]
     // simple events handler that just records the events it receives.
@@ -895,12 +887,8 @@ mod tests {
         add_test_link(&mut global_network, "X", "K", "TX", 75.0, 3600.0, 100.0);
         add_test_link(&mut global_network, "Y", "K", "TY", 75.0, 3600.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         set_node_rng(&mut network, "K", 4712);
         let node_id = Id::create("K");
         let first_draw = network.rng.get(&node_id).unwrap().clone().random::<f64>();
@@ -931,12 +919,8 @@ mod tests {
         add_test_link(&mut global_network, "B", "SB", "K", 1.0, 7200.0, 100.0);
         add_test_link(&mut global_network, "C", "K", "T", 15.0, 7200.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         set_node_rng(&mut network, "K", 4711);
         for id in 1..=10_000 {
             network.send_veh_en_route(test_vehicle(id, vec!["A", "C"]), None, 0);
@@ -977,12 +961,8 @@ mod tests {
         add_test_link(&mut global_network, "Y", "K", "TY", 7.5, 3600.0, 100.0);
         add_test_link(&mut global_network, "X2", "TX", "END", 7.5, 3600.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         push_vehicle_to_queue(&mut network, "X", 90, vec!["X", "X2"], 0);
         network.send_veh_en_route(test_vehicle(11, vec!["A", "X"]), None, 0);
         network.send_veh_en_route(test_vehicle(21, vec!["B", "Y"]), None, 0);
@@ -1009,12 +989,8 @@ mod tests {
         add_test_link(&mut global_network, "Y", "K", "TY", 7.5, 3600.0, 100.0);
         add_test_link(&mut global_network, "X2", "TX", "END", 7.5, 3600.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         push_vehicle_to_queue(&mut network, "X", 90, vec!["X", "X2"], 0);
         network.send_veh_en_route(test_vehicle(11, vec!["A", "X"]), None, 0);
         network.send_veh_en_route(test_vehicle(12, vec!["A", "Y"]), None, 0);
@@ -1039,14 +1015,9 @@ mod tests {
         add_test_link(&mut global_network, "C", "K", "T", 15.0, 7200.0, 100.0);
         add_test_link(&mut global_network, "C2", "T", "END", 7.5, 3600.0, 100.0);
 
-        let mut qsim_config = test_utils::config();
-        qsim_config.stuck_threshold = 10;
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &qsim_config,
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut config = test_utils::config();
+        config.qsim_mut().stuck_threshold = 10;
+        let mut network = SimNetworkPartition::from_network_for_test(&global_network, 0, &config);
         push_vehicle_to_queue(&mut network, "C", 90, vec!["C", "C2"], 0);
         network.send_veh_en_route(test_vehicle(11, vec!["A", "C"]), None, 0);
         network.send_veh_en_route(test_vehicle(12, vec!["A", "C"]), None, 0);
@@ -1074,12 +1045,8 @@ mod tests {
         add_test_link(&mut global_network, "C", "K", "T", 100.0, 3600.0, 1.0);
         add_test_link(&mut global_network, "C2", "T", "END", 7.5, 3600.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         for id in 100..114 {
             push_vehicle_to_queue(&mut network, "C", id, vec!["C", "C2"], 0);
         }
@@ -1108,12 +1075,8 @@ mod tests {
         add_test_nodes(&mut global_network, &["S", "K"]);
         add_test_link(&mut global_network, "A", "S", "K", 1.0, 3600.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         network.send_veh_en_route(test_vehicle(1, vec!["A", "missing"]), None, 0);
 
         let (mut env, events) = environment_with_transition_events();
@@ -1137,12 +1100,8 @@ mod tests {
         add_test_link(&mut global_network, "A", "S", "K1", 1.0, 3600.0, 100.0);
         add_test_link(&mut global_network, "Z", "K2", "T", 75.0, 3600.0, 100.0);
 
-        let mut network = test_network_partition(
-            &global_network,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         network.send_veh_en_route(test_vehicle(1, vec!["A", "Z"]), None, 0);
 
         let (mut env, events) = environment_with_transition_events();
@@ -1170,9 +1129,8 @@ mod tests {
         add_test_link(&mut global_network, "D", "K", "T", 7.5, 3600.0, 100.0);
         add_test_link(&mut global_network, "A2", "K", "TA", 7.5, 3600.0, 100.0);
 
-        let base_seed = config::DEFAULT_RANDOM_SEED;
         let mut network =
-            test_network_partition(&global_network, 0, &test_utils::config(), base_seed);
+            SimNetworkPartition::from_network_for_test(&global_network, 0, &test_utils::config());
         set_node_rng(&mut network, "K", 4711);
         let slow_vehicle = SimulationVehicle::from_parts(
             1,
@@ -1231,13 +1189,11 @@ mod tests {
     /// Expectation: Both insertion orders select the same incoming link and produce the same LinkLeave event sequence.
     #[deterministic_id_test]
     fn inlink_selection_uses_external_id_order() {
-        let base_seed = config::DEFAULT_RANDOM_SEED;
         let node_id = Id::create("K");
-        let mut abc_network = test_network_partition(
+        let mut abc_network = SimNetworkPartition::from_network_for_test(
             &three_way_merge_network(&["A", "B", "C"]),
             0,
             &test_utils::config(),
-            base_seed,
         );
         set_node_rng(&mut abc_network, "K", 0);
         let first_draw = abc_network
@@ -1251,11 +1207,10 @@ mod tests {
             "The fixed seed must select an outer third, draw was {first_draw}"
         );
 
-        let mut cba_network = test_network_partition(
+        let mut cba_network = SimNetworkPartition::from_network_for_test(
             &three_way_merge_network(&["C", "B", "A"]),
             0,
             &test_utils::config(),
-            base_seed,
         );
         set_node_rng(&mut cba_network, "K", 0);
         for (id, link) in [(1, "A"), (2, "B"), (3, "C")] {
@@ -1341,12 +1296,8 @@ mod tests {
             1,
             &PartitionMethod::Metis(MetisOptions::default()),
         );
-        let mut network = test_network_partition(
-            &global_net,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_net, 0, &test_utils::config());
         let agent = test_utils::create_agent(1, vec!["link1", "link2", "link3"]);
         let vehicle = SimulationVehicle::from_parts(1, 0, 10., 1., agent);
         network.send_veh_en_route(vehicle, None, 0);
@@ -1392,12 +1343,8 @@ mod tests {
             2,
             &PartitionMethod::None,
         );
-        let mut network = test_network_partition(
-            &global_net,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_net, 0, &test_utils::config());
         let agent = test_utils::create_agent(1, vec!["link1", "link2", "link3"]);
         let vehicle = SimulationVehicle::from_parts(1, 0, 10., 100., agent);
         network.send_veh_en_route(vehicle, None, 0);
@@ -1431,12 +1378,8 @@ mod tests {
             1,
             &PartitionMethod::Metis(MetisOptions::default()),
         );
-        let mut network = test_network_partition(
-            &global_net,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut network =
+            SimNetworkPartition::from_network_for_test(&global_net, 0, &test_utils::config());
 
         // place 100 vehicles on first link
         for i in 0..100 {
@@ -1472,9 +1415,8 @@ mod tests {
         let id_2: Id<Link> = Id::get_from_ext("link2");
         let id_3: Id<Link> = Id::get_from_ext("link3");
         let mut config = test_utils::config();
-        config.stuck_threshold = u32::MAX;
-        let mut network =
-            test_network_partition(&global_net, 0, &config, config::DEFAULT_RANDOM_SEED);
+        config.qsim_mut().stuck_threshold = u32::MAX;
+        let mut network = SimNetworkPartition::from_network_for_test(&global_net, 0, &config);
 
         // Place 10 vehicles on link1. They will be released every 10s because PCE is 10 and flow_cap is 1.
         // Since they are super slow, they will leave link2 after 1000s.
@@ -1572,9 +1514,8 @@ mod tests {
         let id_2: Id<Link> = Id::get_from_ext("link2");
         let id_3: Id<Link> = Id::get_from_ext("link3");
         let mut config = test_utils::config();
-        config.stuck_threshold = 10;
-        let mut network =
-            test_network_partition(&global_net, 0, &config, config::DEFAULT_RANDOM_SEED);
+        config.qsim_mut().stuck_threshold = 10;
+        let mut network = SimNetworkPartition::from_network_for_test(&global_net, 0, &config);
 
         // Place 10 vehicles on link1. They will be released every 10s because PCE is 10 and flow_cap is 1.
         // Since they are super slow, they will leave link2 after 1000s.
@@ -1731,7 +1672,7 @@ mod tests {
             attributes: Default::default(),
         });
         let mut sim_net =
-            test_network_partition(&net, 0, &test_utils::config(), config::DEFAULT_RANDOM_SEED);
+            SimNetworkPartition::from_network_for_test(&net, 0, &test_utils::config());
 
         // Place 1000 vehicles on link1. Flow cap: 1 veh/s
         for i in 0..1000 {
@@ -1865,8 +1806,7 @@ mod tests {
         net.add_link(out_link_1_2);
         net.add_link(out_link_3_1);
 
-        let sim_net =
-            test_network_partition(&net, 0, &test_utils::config(), config::DEFAULT_RANDOM_SEED);
+        let sim_net = SimNetworkPartition::from_network_for_test(&net, 0, &test_utils::config());
 
         let neighbors = sim_net.neighbors();
         assert_eq!(3, neighbors.len());
@@ -1898,18 +1838,8 @@ mod tests {
         network.add_link(link2);
 
         vec![
-            test_network_partition(
-                network,
-                0,
-                &test_utils::config(),
-                config::DEFAULT_RANDOM_SEED,
-            ),
-            test_network_partition(
-                network,
-                1,
-                &test_utils::config(),
-                config::DEFAULT_RANDOM_SEED,
-            ),
+            SimNetworkPartition::from_network_for_test(network, 0, &test_utils::config()),
+            SimNetworkPartition::from_network_for_test(network, 1, &test_utils::config()),
         ]
     }
 }

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -5,6 +5,7 @@ use crate::simulation::controller::ThreadLocalComputationalEnvironment;
 use crate::simulation::events::{EventsManager, LinkEnterEventBuilder, LinkLeaveEventBuilder};
 use crate::simulation::id::Id;
 use crate::simulation::id::serializable_type::StableTypeId;
+use crate::simulation::network::LinkStorageCapacities;
 use crate::simulation::network::link::LinkPosition::{QStart, Waiting};
 use crate::simulation::network::stuck_timer::StuckTimer;
 use crate::simulation::scenario::network::{Link, Network, Node};
@@ -114,6 +115,7 @@ enum FrontDecision {
 impl SimNetworkPartition {
     pub fn from_network(
         global_network: &Network,
+        storage_capacities: &LinkStorageCapacities,
         partition: u32,
         config: &config::QSim,
         base_seed: u64,
@@ -140,8 +142,8 @@ impl SimNetworkPartition {
                     link.id.clone(),
                     Self::create_sim_link(
                         link,
+                        storage_capacities,
                         partition,
-                        global_network.effective_cell_size(),
                         config,
                         global_network,
                     ),
@@ -184,26 +186,22 @@ impl SimNetworkPartition {
 
     fn create_sim_link(
         link: &Link,
+        storage_capacities: &LinkStorageCapacities,
         partition: u32,
-        effective_cell_size: f64,
         config: &config::QSim,
         global_network: &Network,
     ) -> SimLink {
         let from_part = global_network.get_node(&link.from).partition; //all_nodes.get(link.from.internal()).unwrap().partition;
         let to_part = global_network.get_node(&link.to).partition; //all_nodes.get(link.to.internal()).unwrap().partition;
+        let storage_capacity = storage_capacities.get(&link.id);
 
         if from_part == to_part {
-            SimLink::Local(LocalLink::from_link(link, effective_cell_size, config))
+            SimLink::Local(LocalLink::from_link(link, storage_capacity, config))
         } else if to_part == partition {
-            let local_link = LocalLink::from_link(link, effective_cell_size, config);
+            let local_link = LocalLink::from_link(link, storage_capacity, config);
             SimLink::In(SplitInLink::new(from_part, local_link))
         } else {
-            SimLink::Out(SplitOutLink::new(
-                link,
-                effective_cell_size,
-                config.sample_size,
-                to_part,
-            ))
+            SimLink::Out(SplitOutLink::new(link, storage_capacity, to_part))
         }
     }
 
@@ -723,6 +721,7 @@ mod tests {
     use crate::simulation::events::{LinkEnterEvent, LinkLeaveEvent};
     use crate::simulation::id::Id;
     use crate::simulation::io::xml::events::XmlEventsWriter;
+    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::link::LinkPosition::QStart;
     use crate::simulation::network::link::SimLink;
     use crate::simulation::network::link::SimLink::Local;
@@ -737,6 +736,22 @@ mod tests {
     use std::cell::RefCell;
     use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::rc::Rc;
+
+    fn test_network_partition(
+        network: &Network,
+        partition: u32,
+        config: &config::QSim,
+        base_seed: u64,
+    ) -> SimNetworkPartition {
+        let storage_capacities = LinkStorageCapacities::from_network(network, config);
+        SimNetworkPartition::from_network(
+            network,
+            &storage_capacities,
+            partition,
+            config,
+            base_seed,
+        )
+    }
 
     #[derive(Clone, Default)]
     // simple events handler that just records the events it receives.
@@ -880,7 +895,7 @@ mod tests {
         add_test_link(&mut global_network, "X", "K", "TX", 75.0, 3600.0, 100.0);
         add_test_link(&mut global_network, "Y", "K", "TY", 75.0, 3600.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -916,7 +931,7 @@ mod tests {
         add_test_link(&mut global_network, "B", "SB", "K", 1.0, 7200.0, 100.0);
         add_test_link(&mut global_network, "C", "K", "T", 15.0, 7200.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -962,7 +977,7 @@ mod tests {
         add_test_link(&mut global_network, "Y", "K", "TY", 7.5, 3600.0, 100.0);
         add_test_link(&mut global_network, "X2", "TX", "END", 7.5, 3600.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -994,7 +1009,7 @@ mod tests {
         add_test_link(&mut global_network, "Y", "K", "TY", 7.5, 3600.0, 100.0);
         add_test_link(&mut global_network, "X2", "TX", "END", 7.5, 3600.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -1026,7 +1041,7 @@ mod tests {
 
         let mut qsim_config = test_utils::config();
         qsim_config.stuck_threshold = 10;
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &qsim_config,
@@ -1049,17 +1064,17 @@ mod tests {
     }
 
     /// Setting: The slow link C is 100 m long, has a free speed of 1 m/s, a capacity of 3600 vehicles/h, and already contains 14 vehicles; U offers one additional vehicle for C.
-    /// Execution: The current cell-based storage capacity of about 13.33 is evaluated without the free-speed adjustment, after which the turn from U to C is checked.
-    /// Expectation: C is considered full, U1 does not leave U, and no LinkLeave event is emitted.
+    /// Execution: The prepared storage capacity is increased from about 13.33 to 100 vehicles based on the free-speed travel time.
+    /// Expectation: C can accept U1, which leaves U and enters C.
     #[deterministic_id_test]
-    fn slow_link_uses_current_cell_based_storage_capacity() {
+    fn slow_link_uses_freespeed_adjusted_storage_capacity() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["S", "K", "T", "END"]);
         add_test_link(&mut global_network, "U", "S", "K", 1.0, 3600.0, 100.0);
         add_test_link(&mut global_network, "C", "K", "T", 100.0, 3600.0, 1.0);
         add_test_link(&mut global_network, "C2", "T", "END", 7.5, 3600.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -1076,11 +1091,12 @@ mod tests {
             14.0,
             network.links.get(&Id::create("C")).unwrap().used_storage()
         );
-        assert!(!network.links.get(&Id::create("C")).unwrap().is_available());
+        assert!(network.links.get(&Id::create("C")).unwrap().is_available());
 
         network.move_nodes(&mut env, 1);
-        assert!(events.leaves_on("U").is_empty());
-        assert_eq!(1, local_vehicle_count(&network, "U"));
+        assert_eq!(vec!["1"], events.leaves_on("U"));
+        assert_eq!(0, local_vehicle_count(&network, "U"));
+        assert_eq!(15, local_vehicle_count(&network, "C"));
     }
 
     /// Setting: A vehicle is waiting on A and names `missing`, a link that is not present in the local network, as its next route element.
@@ -1092,7 +1108,7 @@ mod tests {
         add_test_nodes(&mut global_network, &["S", "K"]);
         add_test_link(&mut global_network, "A", "S", "K", 1.0, 3600.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -1121,7 +1137,7 @@ mod tests {
         add_test_link(&mut global_network, "A", "S", "K1", 1.0, 3600.0, 100.0);
         add_test_link(&mut global_network, "Z", "K2", "T", 75.0, 3600.0, 100.0);
 
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_network,
             0,
             &test_utils::config(),
@@ -1156,7 +1172,7 @@ mod tests {
 
         let base_seed = config::DEFAULT_RANDOM_SEED;
         let mut network =
-            SimNetworkPartition::from_network(&global_network, 0, &test_utils::config(), base_seed);
+            test_network_partition(&global_network, 0, &test_utils::config(), base_seed);
         set_node_rng(&mut network, "K", 4711);
         let slow_vehicle = SimulationVehicle::from_parts(
             1,
@@ -1217,7 +1233,7 @@ mod tests {
     fn inlink_selection_uses_external_id_order() {
         let base_seed = config::DEFAULT_RANDOM_SEED;
         let node_id = Id::create("K");
-        let mut abc_network = SimNetworkPartition::from_network(
+        let mut abc_network = test_network_partition(
             &three_way_merge_network(&["A", "B", "C"]),
             0,
             &test_utils::config(),
@@ -1235,7 +1251,7 @@ mod tests {
             "The fixed seed must select an outer third, draw was {first_draw}"
         );
 
-        let mut cba_network = SimNetworkPartition::from_network(
+        let mut cba_network = test_network_partition(
             &three_way_merge_network(&["C", "B", "A"]),
             0,
             &test_utils::config(),
@@ -1325,7 +1341,7 @@ mod tests {
             1,
             &PartitionMethod::Metis(MetisOptions::default()),
         );
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_net,
             0,
             &test_utils::config(),
@@ -1376,7 +1392,7 @@ mod tests {
             2,
             &PartitionMethod::None,
         );
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_net,
             0,
             &test_utils::config(),
@@ -1415,7 +1431,7 @@ mod tests {
             1,
             &PartitionMethod::Metis(MetisOptions::default()),
         );
-        let mut network = SimNetworkPartition::from_network(
+        let mut network = test_network_partition(
             &global_net,
             0,
             &test_utils::config(),
@@ -1458,7 +1474,7 @@ mod tests {
         let mut config = test_utils::config();
         config.stuck_threshold = u32::MAX;
         let mut network =
-            SimNetworkPartition::from_network(&global_net, 0, &config, config::DEFAULT_RANDOM_SEED);
+            test_network_partition(&global_net, 0, &config, config::DEFAULT_RANDOM_SEED);
 
         // Place 10 vehicles on link1. They will be released every 10s because PCE is 10 and flow_cap is 1.
         // Since they are super slow, they will leave link2 after 1000s.
@@ -1558,7 +1574,7 @@ mod tests {
         let mut config = test_utils::config();
         config.stuck_threshold = 10;
         let mut network =
-            SimNetworkPartition::from_network(&global_net, 0, &config, config::DEFAULT_RANDOM_SEED);
+            test_network_partition(&global_net, 0, &config, config::DEFAULT_RANDOM_SEED);
 
         // Place 10 vehicles on link1. They will be released every 10s because PCE is 10 and flow_cap is 1.
         // Since they are super slow, they will leave link2 after 1000s.
@@ -1714,12 +1730,8 @@ mod tests {
             partition: 0,
             attributes: Default::default(),
         });
-        let mut sim_net = SimNetworkPartition::from_network(
-            &net,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let mut sim_net =
+            test_network_partition(&net, 0, &test_utils::config(), config::DEFAULT_RANDOM_SEED);
 
         // Place 1000 vehicles on link1. Flow cap: 1 veh/s
         for i in 0..1000 {
@@ -1853,12 +1865,8 @@ mod tests {
         net.add_link(out_link_1_2);
         net.add_link(out_link_3_1);
 
-        let sim_net = SimNetworkPartition::from_network(
-            &net,
-            0,
-            &test_utils::config(),
-            config::DEFAULT_RANDOM_SEED,
-        );
+        let sim_net =
+            test_network_partition(&net, 0, &test_utils::config(), config::DEFAULT_RANDOM_SEED);
 
         let neighbors = sim_net.neighbors();
         assert_eq!(3, neighbors.len());
@@ -1890,13 +1898,13 @@ mod tests {
         network.add_link(link2);
 
         vec![
-            SimNetworkPartition::from_network(
+            test_network_partition(
                 network,
                 0,
                 &test_utils::config(),
                 config::DEFAULT_RANDOM_SEED,
             ),
-            SimNetworkPartition::from_network(
+            test_network_partition(
                 network,
                 1,
                 &test_utils::config(),

--- a/rust_qsim/src/simulation/network/sim_network.rs
+++ b/rust_qsim/src/simulation/network/sim_network.rs
@@ -1,6 +1,6 @@
 use super::link::{LocalLink, SimLink, SplitInLink, SplitOutLink};
 use crate::simulation::agents::agent::SimulationAgent;
-use crate::simulation::agents::{AgentEvent, EnvironmentalEventObserver, SimulationAgentLogic};
+use crate::simulation::agents::{AgentEvent, EnvironmentalEventObserver};
 use crate::simulation::controller::ThreadLocalComputationalEnvironment;
 use crate::simulation::events::{EventsManager, LinkEnterEventBuilder, LinkLeaveEventBuilder};
 use crate::simulation::id::Id;
@@ -58,6 +58,7 @@ impl<C: StableTypeId + 'static> ActiveCache<C> {
         self.active.len()
     }
 
+    #[cfg(test)]
     fn contains(&self, id: &Id<C>) -> bool {
         self.active.contains(id)
     }
@@ -90,6 +91,21 @@ pub struct SimNetworkPartition {
 pub struct SimNode {
     id: Id<Node>,
     in_links: Vec<Id<Link>>,
+}
+
+#[derive(Debug)]
+struct Candidate<'a> {
+    id: &'a Id<Link>,
+    weight: f64,
+}
+
+#[derive(Debug, PartialEq)]
+enum FrontDecision {
+    NoVehicle,
+    MoveNormally,
+    MoveAlthoughStuck,
+    Wait,
+    Abort,
 }
 
 impl SimNetworkPartition {
@@ -146,7 +162,8 @@ impl SimNetworkPartition {
     }
 
     fn create_sim_node(node: &Node) -> SimNode {
-        let in_links: Vec<_> = node.in_links.to_vec();
+        let mut in_links: Vec<_> = node.in_links.to_vec();
+        in_links.sort_unstable_by(|a, b| a.external().cmp(b.external()));
 
         SimNode {
             id: node.id.clone(),
@@ -377,7 +394,7 @@ impl SimNetworkPartition {
         comp_env: &mut ThreadLocalComputationalEnvironment,
     ) -> MoveSingleLinkResult {
         let vehicles_end_leg = link.do_sim_step(now, comp_env);
-        if link.to_nodes_active(now) {
+        if link.to_nodes_active() {
             active_nodes.activate(link.to.clone());
         }
 
@@ -460,82 +477,61 @@ impl SimNetworkPartition {
         now: Tick,
     ) -> bool {
         let node = self.nodes.get(node_id).unwrap();
-        // Get node-specific RNG using node id and current time as hash
-        // This ensures determinism while maintaining different behavior across time steps
-        let (active, mut avail_capacity) =
-            Self::get_active_in_links(&node.in_links, &self.active_links, &self.links);
-        let mut exhausted_links: Vec<bool> = vec![false; active.len()];
-        let mut sel_cap: f64 = 0.;
+        let (mut candidates, mut total_capacity) =
+            Self::get_candidates(&node.in_links, &self.links, now);
+        let rng = self.rng.get_mut(node_id).unwrap();
 
-        while avail_capacity > 1e-10 {
-            // draw random number between 0 and available capacity
-            let r = self.rng.get_mut(node_id).unwrap().random::<f64>();
-            let rnd_num: f64 = r * avail_capacity;
+        while !candidates.is_empty() && total_capacity > 1e-10 {
+            let rnd_num = rng.random::<f64>() * total_capacity;
+            let selected_index = Self::weighted_index(&candidates, rnd_num);
+            let selected = candidates.remove(selected_index);
+            total_capacity -= selected.weight;
 
-            #[allow(clippy::needless_range_loop)]
-            // go through all in links and fetch one, which is not exhausted yet.
-            for i in 0..active.len() {
-                // if the link is exhausted, try next link
-                if exhausted_links[i] {
-                    // reduce the available capacity a little bit. Sometimes we have rounding errors
-                    // which will cause an infinite loop. Reducing the remaining capacity a little
-                    // bit at least prevents infinite loops.
-                    avail_capacity -= 1e-6;
-                    continue;
-                }
-
-                // take the not exhausted link and check whether it could release a vehicle and if
-                // that vehicle can move to the next link
-                let link_id = active.get(i).unwrap();
-                if Self::should_veh_move_out(link_id, &self.links, now) {
-                    // the vehicle can move. Increase the selected capacity by the link's capacity
-                    // this way it becomes more and more likely that a link can release vehicles,
-                    // links with more capacity are more likely to release vehicles first though.
-                    let in_link = self.links.get_mut(link_id).unwrap();
-                    sel_cap += in_link.flow_cap();
-
-                    if sel_cap >= rnd_num {
-                        let veh = in_link.pop_veh().expect("No vehicle on link");
-                        Self::move_vehicle(
-                            veh,
-                            &mut self.links,
-                            &mut self.active_links,
-                            comp_env,
-                            self.clock,
-                            now,
-                        );
-                    }
-                } else {
-                    // in case the vehicle on the link can't move, we add the link to the exhausted
-                    // bookkeeping and reduce the available capacity, which makes it more likely for
-                    // other links to be able to release vehicles.
-                    exhausted_links[i] = true;
-                    let link = self.links.get(link_id).unwrap();
-                    avail_capacity -= link.flow_cap();
-                }
-            }
+            let aborted = Self::drain_selected_inlink(
+                selected.id,
+                &mut self.links,
+                &mut self.active_links,
+                comp_env,
+                self.clock,
+                now,
+            );
+            self.veh_counter -= aborted;
         }
+
         // check whether any link is offering next timestep. Otherwise the node can be de-activated
-        Self::any_link_offers(&active, &self.links, now.next())
+        Self::any_link_offers(&node.in_links, &self.links, now.next())
     }
 
-    fn get_active_in_links(
-        in_links: &Vec<Id<Link>>,
-        active_links: &ActiveCache<Link>,
+    fn get_candidates<'a>(
+        in_links: &'a [Id<Link>],
         links: &IntMap<Id<Link>, SimLink>,
-    ) -> (Vec<Id<Link>>, f64) {
-        let mut active = Vec::new();
-        let mut acc_cap = 0.;
+        now: Tick,
+    ) -> (Vec<Candidate<'a>>, f64) {
+        let mut candidates = Vec::with_capacity(in_links.len());
+        let mut total_capacity = 0.;
 
         for id in in_links {
-            if active_links.contains(id) {
-                active.push(id.clone());
-                let link = links.get(id).unwrap();
-                acc_cap += link.flow_cap();
+            let link = links.get(id).unwrap();
+            if link.offers_veh(now).is_some() {
+                let weight = link.flow_cap();
+                candidates.push(Candidate { id, weight });
+                total_capacity += weight;
             }
         }
 
-        (active, acc_cap)
+        (candidates, total_capacity)
+    }
+
+    fn weighted_index(candidates: &[Candidate], weighted_rnd_capacity: f64) -> usize {
+        let mut selected_capacity = 0.;
+        for (index, candidate) in candidates.iter().enumerate() {
+            selected_capacity += candidate.weight;
+            if selected_capacity >= weighted_rnd_capacity {
+                return index;
+            }
+        }
+
+        candidates.len() - 1
     }
 
     fn any_link_offers(
@@ -549,31 +545,85 @@ impl SimNetworkPartition {
             .any(|link| link.offers_veh(time).is_some())
     }
 
-    fn should_veh_move_out(in_id: &Id<Link>, links: &IntMap<Id<Link>, SimLink>, now: Tick) -> bool {
+    fn evaluate_front_vehicle(
+        in_id: &Id<Link>,
+        links: &IntMap<Id<Link>, SimLink>,
+        now: Tick,
+    ) -> FrontDecision {
         let in_link = links.get(in_id).unwrap();
-        if let Some(veh_ref) = in_link.offers_veh(now) {
-            return if let Some(next_id) = veh_ref.peek_next_route_element() {
-                // if the vehicle has a next link id, it should move out of the current link.
-                // if the vehicle has reached its stuck threshold, we push it to the next link regardless of the available
-                // storage capacity. Under normal conditions, we check whether the downstream link has storage capacity available
-                let out_link = links.get(next_id).unwrap_or_else(|| {
-                    panic!(
-                        "Link id {:?} was not in local network. Vehicle's leg is: {:?}",
-                        next_id,
-                        veh_ref.driver().curr_leg()
-                    )
-                });
-                in_link.is_veh_stuck(now) || out_link.is_available()
-            } else {
-                panic!(
-                    "Vehicle {:?} is offered by link {:?} but has no next link. This should not happen. Leg ends are handled in move_links, not move_nodes.",
-                    veh_ref.id(),
-                    in_link.id()
-                )
-            };
+        let Some(vehicle) = in_link.offers_veh(now) else {
+            return FrontDecision::NoVehicle;
+        };
+        let Some(next_id) = vehicle.peek_next_route_element() else {
+            return FrontDecision::Abort;
+        };
+        let Some(out_link) = links.get(next_id) else {
+            return FrontDecision::Abort;
+        };
+        if in_link.to() != out_link.from() {
+            return FrontDecision::Abort;
         }
-        // if the link doesn't have a vehicle to offer, we don't have to do anything.
-        false
+        if out_link.is_available() {
+            FrontDecision::MoveNormally
+        } else if in_link.is_veh_stuck(now) {
+            FrontDecision::MoveAlthoughStuck
+        } else {
+            FrontDecision::Wait
+        }
+    }
+
+    fn drain_selected_inlink(
+        in_link_id: &Id<Link>,
+        links: &mut IntMap<Id<Link>, SimLink>,
+        active_links: &mut ActiveCache<Link>,
+        comp_env: &mut ThreadLocalComputationalEnvironment,
+        clock: SimClock,
+        now: Tick,
+    ) -> usize {
+        let mut aborted = 0;
+        loop {
+            match Self::evaluate_front_vehicle(in_link_id, links, now) {
+                FrontDecision::MoveNormally | FrontDecision::MoveAlthoughStuck => {
+                    let vehicle = links
+                        .get_mut(in_link_id)
+                        .unwrap()
+                        .pop_veh(now)
+                        .expect("No vehicle on selected link");
+                    Self::move_vehicle(vehicle, links, active_links, comp_env, clock, now);
+                }
+                FrontDecision::Abort => {
+                    let vehicle = links
+                        .get_mut(in_link_id)
+                        .unwrap()
+                        .pop_veh(now)
+                        .expect("No vehicle on selected link");
+                    Self::abort_vehicle(vehicle, comp_env, clock, now);
+                    aborted += 1;
+                }
+                FrontDecision::Wait | FrontDecision::NoVehicle => break,
+            }
+        }
+
+        if !links.get(in_link_id).unwrap().is_active() {
+            active_links.deactivate(in_link_id);
+        }
+        aborted
+    }
+
+    fn abort_vehicle(
+        vehicle: SimulationVehicle,
+        comp_env: &mut ThreadLocalComputationalEnvironment,
+        clock: SimClock,
+        now: Tick,
+    ) {
+        comp_env.events_manager_borrow_mut().process_event(
+            &LinkLeaveEventBuilder::default()
+                .vehicle(vehicle.id().clone())
+                .link(vehicle.curr_link_id().unwrap().clone())
+                .time(clock.tick_to_time(now))
+                .build()
+                .unwrap(),
+        );
     }
 
     /// Moves the vehicle from the current link to the next link.
@@ -638,7 +688,7 @@ struct MoveSingleLinkResult {
 
 #[cfg(test)]
 mod tests {
-    use super::SimNetworkPartition;
+    use super::{Candidate, SimNetworkPartition};
     use crate::simulation::config;
     use crate::simulation::config::{MetisOptions, PartitionMethod};
     use crate::simulation::controller::ThreadLocalComputationalEnvironment;
@@ -657,7 +707,6 @@ mod tests {
     use rand::rngs::SmallRng;
     use rand::{RngExt, SeedableRng};
     use std::cell::RefCell;
-    use std::panic::{AssertUnwindSafe, catch_unwind};
     use std::rc::Rc;
 
     #[derive(Clone, Default)]
@@ -790,11 +839,11 @@ mod tests {
         network
     }
 
-    /// Setting: A offers A1 with capacity 1, while B offers B1/B2 with capacity 2; the fixed seed places the first selection in B's capacity interval.
-    /// Execution: A single node transition processes the offered vehicles using the current selection capacity, which accumulates across scans.
-    /// Expectation: The exact LinkLeave order is B1, A1, B2 (vehicle IDs 21, 11, 22).
+    /// Setting: A offers A1 with capacity 1, while B offers B1/B2 with capacity 2; the fixed seed selects B first.
+    /// Execution: A single node transition drains the selected B buffer before selecting and processing A.
+    /// Expectation: The exact LinkLeave order is B1, B2, A1 (vehicle IDs 21, 22, 11).
     #[deterministic_id_test]
-    fn current_transition_interleaves_selected_buffers() {
+    fn selected_inlink_buffer_is_drained_before_next_selection() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["SA", "SB", "K", "TX", "TY"]);
         add_test_link(&mut global_network, "A", "SA", "K", 1.0, 3600.0, 100.0);
@@ -824,14 +873,14 @@ mod tests {
         network.move_links(&mut env, 0);
         network.move_nodes(&mut env, 1);
 
-        assert_eq!(vec!["21", "11", "22"], events.leaving_vehicles());
+        assert_eq!(vec!["21", "22", "11"], events.leaving_vehicles());
     }
 
-    /// Setting: A can offer one vehicle per tick and B can offer two; their shared destination link C has storage capacity for exactly two vehicles and is emptied every tick.
-    /// Execution: 100 node transitions run while both incoming links remain supplied.
-    /// Expectation: In the current Rust implementation, exactly one vehicle leaves A and one leaves B per tick, resulting in 100 vehicles from each link.
+    /// Setting: A has weight 1, B has weight 2, both remain supplied, and C has room for exactly two vehicles per tick.
+    /// Execution: 10,000 node transitions select each candidate at most once and drain the selected buffer until C is full.
+    /// Expectation: Total throughput is exactly two vehicles per tick, with approximately one third from A and five thirds from B per tick.
     #[deterministic_id_test]
-    fn current_merge_moves_one_vehicle_per_inlink_and_tick() {
+    fn merge_throughput_follows_buffer_weighted_selection() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["SA", "SB", "K", "T"]);
         add_test_link(&mut global_network, "A", "SA", "K", 1.0, 3600.0, 100.0);
@@ -844,23 +893,31 @@ mod tests {
             &test_utils::config(),
             config::DEFAULT_RANDOM_SEED,
         );
-        for id in 1..=100 {
+        set_node_rng(&mut network, "K", 4711);
+        for id in 1..=10_000 {
             network.send_veh_en_route(test_vehicle(id, vec!["A", "C"]), None, 0);
         }
-        for id in 101..=300 {
+        for id in 10_001..=30_000 {
             network.send_veh_en_route(test_vehicle(id, vec!["B", "C"]), None, 0);
         }
 
         let (mut env, events) = environment_with_transition_events();
         network.move_links(&mut env, 0);
-        for now in 1..=100 {
+        for now in 1..=10_000 {
             network.move_nodes(&mut env, now);
             network.move_links(&mut env, now);
         }
 
-        assert_eq!(100, events.leaves_on("A").len());
-        assert_eq!(100, events.leaves_on("B").len());
-        assert_eq!(200, events.link_leaves.borrow().len());
+        let from_a = events.leaves_on("A").len();
+        let from_b = events.leaves_on("B").len();
+        assert_eq!(20_000, from_a + from_b);
+
+        // assert 1/3 from A and 5/3 from B. There are the following cases:
+        // (1) A is chosen first (p=1/3) => A releases 1 and B releases 1
+        // (2) B is chosen first (p=2/3) => A releases 0 and B releases 2
+        // => Expected value E(A)=1*1/3+0=1/3; E(B)=1/3*1+2/3*2=5/3
+        assert!(from_a.abs_diff(10_000 / 3) <= 250, "A count was {from_a}");
+        assert!(from_b.abs_diff(50_000 / 3) <= 250, "B count was {from_b}");
     }
 
     /// Setting: A1 wants to enter the already full link X, while B1 independently wants to enter the available link Y.
@@ -998,10 +1055,10 @@ mod tests {
     }
 
     /// Setting: A vehicle is waiting on A and names `missing`, a link that is not present in the local network, as its next route element.
-    /// Execution: The node attempts to resolve the unknown destination link in `should_veh_move_out`.
-    /// Expectation: The current implementation panics before moving the vehicle; it remains on A and no LinkLeave event is emitted.
+    /// Execution: The selected A buffer evaluates the unknown destination as an invalid turn and aborts the vehicle.
+    /// Expectation: The vehicle leaves A without a LinkEnter event or panic, is discarded, and is removed from the network count.
     #[deterministic_id_test]
-    fn missing_next_link_panics_before_link_leave() {
+    fn missing_next_link_aborts_vehicle() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["S", "K"]);
         add_test_link(&mut global_network, "A", "S", "K", 1.0, 3600.0, 100.0);
@@ -1016,18 +1073,19 @@ mod tests {
 
         let (mut env, events) = environment_with_transition_events();
         network.move_links(&mut env, 0);
-        let result = catch_unwind(AssertUnwindSafe(|| network.move_nodes(&mut env, 1)));
+        network.move_nodes(&mut env, 1);
 
-        assert!(result.is_err());
-        assert!(events.link_leaves.borrow().is_empty());
-        assert_eq!(1, local_vehicle_count(&network, "A"));
+        assert_eq!(vec!["1"], events.leaves_on("A"));
+        assert!(events.link_enters.borrow().is_empty());
+        assert_eq!(0, local_vehicle_count(&network, "A"));
+        assert_eq!(0, network.veh_on_net());
     }
 
     /// Setting: A ends at K1, while the next route link Z begins at the topologically disconnected node K2; both links belong to the same partition.
-    /// Execution: The vehicle is processed at K1 without validating the connection from A to Z.
-    /// Expectation: The current implementation accepts the turn, emits LinkLeave(A) and LinkEnter(Z), and places the vehicle directly on Z.
+    /// Execution: The selected A buffer compares A's destination node with Z's origin node and aborts the invalid turn.
+    /// Expectation: The vehicle leaves A without entering Z, is discarded, and is removed from the network count.
     #[deterministic_id_test]
-    fn disconnected_next_link_is_accepted() {
+    fn disconnected_next_link_aborts_vehicle() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["S", "K1", "K2", "T"]);
         add_test_link(&mut global_network, "A", "S", "K1", 1.0, 3600.0, 100.0);
@@ -1046,19 +1104,17 @@ mod tests {
         network.move_nodes(&mut env, 1);
 
         assert_eq!(vec!["1"], events.leaves_on("A"));
-        assert_eq!(
-            vec![("Z".to_owned(), "1".to_owned())],
-            *events.link_enters.borrow()
-        );
+        assert!(events.link_enters.borrow().is_empty());
         assert_eq!(0, local_vehicle_count(&network, "A"));
-        assert_eq!(1, local_vehicle_count(&network, "Z"));
+        assert_eq!(0, local_vehicle_count(&network, "Z"));
+        assert_eq!(0, network.veh_on_net());
     }
 
     /// Setting: A is active with capacity 100 but does not yet offer a vehicle at tick 1; B and C each offer a vehicle with capacity 1, and D has only one available slot.
-    /// Execution: A is nevertheless included with B and C in the candidate set and the total capacity of 102; the fixed seed makes the first scan select no vehicle.
-    /// Expectation: The current transition consumes three RNG draws, then moves only B's vehicle and emits no LinkLeave event for A or C.
+    /// Execution: Candidate collection excludes A, and the fixed seed selects C before B from the externally sorted candidate list.
+    /// Expectation: The candidate capacity is 2, C moves first and fills D, and exactly two RNG draws are consumed.
     #[deterministic_id_test]
-    fn non_offering_active_link_is_currently_a_candidate() {
+    fn non_offering_active_link_is_not_a_candidate() {
         let mut global_network = Network::new();
         add_test_nodes(&mut global_network, &["SA", "SB", "SC", "K", "TA", "T"]);
         add_test_link(&mut global_network, "A", "SA", "K", 100.0, 360000.0, 1.0);
@@ -1091,46 +1147,43 @@ mod tests {
         let (mut env, events) = environment_with_transition_events();
         network.move_links(&mut env, 0);
         let node_id = Id::create("K");
-        let (active, capacity) = {
+        let (candidates, capacity) = {
             let node = network.nodes.get(&node_id).unwrap();
-            SimNetworkPartition::get_active_in_links(
-                &node.in_links,
-                &network.active_links,
-                &network.links,
-            )
+            SimNetworkPartition::get_candidates(&node.in_links, &network.links, 1.into())
         };
         assert_eq!(
-            vec![Id::create("A"), Id::create("B"), Id::create("C")],
-            active
+            vec!["B", "C"],
+            candidates
+                .iter()
+                .map(|candidate| candidate.id.external().to_owned())
+                .collect::<Vec<_>>()
         );
-        assert_eq!(102.0, capacity);
+        assert_eq!(2.0, capacity);
 
         let mut expected_rng = network.rng.get(&node_id).unwrap().clone();
         let first_draw = expected_rng.random::<f64>();
         assert!(
-            first_draw > 2.0 / 102.0,
-            "The first draw must miss B and C when A contributes capacity: {first_draw}"
+            first_draw > 0.5,
+            "The first draw must select C from equally weighted B and C: {first_draw}"
         );
         expected_rng.random::<f64>();
-        expected_rng.random::<f64>();
-        let fourth_draw = expected_rng.random::<u64>();
+        let third_draw = expected_rng.random::<u64>();
 
-        // move nodes calls 3 times the rng: Choose A, mark it as exhausted; choose B, move vehicle & mark it as exhausted; choose C, but D is blocked, so mark it as exhausted.
+        // move nodes calls 2 times the rng: choose B, move vehicle & mark it as exhausted; choose C, but D is blocked, so mark it as exhausted.
         network.move_nodes(&mut env, 1);
-        let actual_fourth_draw = network.rng.get_mut(&node_id).unwrap().random::<u64>();
+        let actual_third_draw = network.rng.get_mut(&node_id).unwrap().random::<u64>();
 
-        // check if move nodes consumed 3 draws and produces the same fourth draw as expected
-        assert_eq!(fourth_draw, actual_fourth_draw);
-        assert_eq!(vec!["2"], events.leaves_on("B"));
+        assert_eq!(third_draw, actual_third_draw);
+        assert_eq!(vec!["3"], events.leaves_on("C"));
         assert!(events.leaves_on("A").is_empty());
-        assert!(events.leaves_on("C").is_empty());
+        assert!(events.leaves_on("B").is_empty());
     }
 
     /// Setting: Two semantically identical three-to-one merges are built with incoming links in A/B/C and C/B/A order respectively, and both use the same seed.
-    /// Execution: One vehicle from each incoming link competes for D's single available slot; the seed deliberately falls within an outer third of the selection distribution.
-    /// Expectation: Because the current implementation iterates in insertion order, mirrored incoming links—and therefore different vehicles—win in the two networks.
+    /// Execution: Network construction sorts both nodes' incoming links by external ID before the same seeded selection is made.
+    /// Expectation: Both insertion orders select the same incoming link and produce the same LinkLeave event sequence.
     #[deterministic_id_test]
-    fn inlink_iteration_follows_network_insertion_order() {
+    fn inlink_selection_uses_external_id_order() {
         let base_seed = config::DEFAULT_RANDOM_SEED;
         let node_id = Id::create("K");
         let mut abc_network = SimNetworkPartition::from_network(
@@ -1170,11 +1223,73 @@ mod tests {
         abc_network.move_nodes(&mut abc_env, 1);
         cba_network.move_nodes(&mut cba_env, 1);
 
-        let expected_abc = if first_draw < 1.0 / 3.0 { "1" } else { "3" };
-        let expected_cba = if first_draw < 1.0 / 3.0 { "3" } else { "1" };
-        assert_eq!(vec![expected_abc], abc_events.leaving_vehicles());
-        assert_eq!(vec![expected_cba], cba_events.leaving_vehicles());
-        assert_ne!(abc_events.leaving_vehicles(), cba_events.leaving_vehicles());
+        let expected = if first_draw < 1.0 / 3.0 { "1" } else { "3" };
+        assert_eq!(vec![expected], abc_events.leaving_vehicles());
+        assert_eq!(vec![expected], cba_events.leaving_vehicles());
+        assert_eq!(abc_events.leaving_vehicles(), cba_events.leaving_vehicles());
+    }
+
+    /// Setting: The weighted candidate intervals are [0, 1] for A and (1, 3] for B.
+    /// Execution: Selection is evaluated exactly at the cumulative boundary and once beyond the accumulated weight to exercise the rounding fallback.
+    /// Expectation: The inclusive boundary selects A, while the fallback selects the final candidate B.
+    #[deterministic_id_test]
+    fn weighted_index_uses_inclusive_boundary_and_last_candidate_fallback() {
+        let a = Id::create("A");
+        let b = Id::create("B");
+        let candidates = vec![
+            Candidate {
+                id: &a,
+                weight: 1.0,
+            },
+            Candidate {
+                id: &b,
+                weight: 2.0,
+            },
+        ];
+
+        assert_eq!(
+            0,
+            SimNetworkPartition::weighted_index(&candidates, 0.9999999)
+        );
+        assert_eq!(0, SimNetworkPartition::weighted_index(&candidates, 1.0));
+        assert_eq!(
+            1,
+            SimNetworkPartition::weighted_index(&candidates, 1.0000001)
+        );
+        assert_eq!(1, SimNetworkPartition::weighted_index(&candidates, 3.1));
+    }
+
+    /// Setting: A's buffer contains an invalid vehicle targeting an unknown link followed by a valid vehicle targeting X.
+    /// Execution: Draining A aborts and removes the invalid front vehicle, then immediately evaluates the new front vehicle in the same tick.
+    /// Expectation: Both vehicles leave A in FIFO order, only the valid vehicle enters X, and one vehicle remains counted on the network.
+    #[deterministic_id_test]
+    fn aborted_front_vehicle_does_not_block_valid_vehicle_behind_it() {
+        let mut global_network = Network::new();
+        add_test_nodes(&mut global_network, &["S", "K", "T"]);
+        add_test_link(&mut global_network, "A", "S", "K", 1.0, 7200.0, 100.0);
+        add_test_link(&mut global_network, "X", "K", "T", 75.0, 3600.0, 100.0);
+
+        let mut network = SimNetworkPartition::from_network(
+            &global_network,
+            0,
+            &test_utils::config(),
+            config::DEFAULT_RANDOM_SEED,
+        );
+        network.send_veh_en_route(test_vehicle(1, vec!["A", "missing"]), None, 0);
+        network.send_veh_en_route(test_vehicle(2, vec!["A", "X"]), None, 0);
+
+        let (mut env, events) = environment_with_transition_events();
+        network.move_links(&mut env, 0);
+        network.move_nodes(&mut env, 1);
+
+        assert_eq!(vec!["1", "2"], events.leaves_on("A"));
+        assert_eq!(
+            vec![("X".to_owned(), "2".to_owned())],
+            *events.link_enters.borrow()
+        );
+        assert_eq!(0, local_vehicle_count(&network, "A"));
+        assert_eq!(1, local_vehicle_count(&network, "X"));
+        assert_eq!(1, network.veh_on_net());
     }
 
     #[deterministic_id_test]
@@ -1486,38 +1601,28 @@ mod tests {
                 assert!(link1.offers_veh(now).is_none());
 
                 // veh0 reaches buffer at 1001 and is released immediately.
-                // veh1 reaches buffer at 1011 and is released at 1021; flow cap is refilled after 10
-                // veh2 reaches q end at 1021 and buffer at 1031 (because of flow cap refill from before) and is released at 1041 (because of stuck timer); flow cap is refilled after 10
+                // veh1 reaches the buffer at 1011 and is released at 1021.
+                // Each following vehicle enters the buffer after nine refill ticks and is released
+                // ten ticks later at the inclusive stuck threshold.
                 // ...
-                if (1011..=1021).contains(&now)
-                    || (1031..=1041).contains(&now)
-                    || (1051..=1061).contains(&now)
-                    || (1071..=1081).contains(&now)
-                    || (1091..=1101).contains(&now)
-                    || (1111..=1121).contains(&now)
-                    || (1131..=1141).contains(&now)
-                    || (1151..=1161).contains(&now)
-                    || (1171..=1181).contains(&now)
+                if (1011..1021).contains(&now)
+                    || (1030..1040).contains(&now)
+                    || (1049..1059).contains(&now)
+                    || (1068..1078).contains(&now)
+                    || (1087..1097).contains(&now)
+                    || (1106..1116).contains(&now)
+                    || (1125..1135).contains(&now)
+                    || (1144..1154).contains(&now)
+                    || (1163..1173).contains(&now)
                 {
                     assert!(
                         link2.offers_veh(now).is_some(),
                         "No vehicle offered at timestep {now}"
                     );
-                    if !(now == 1021
-                        || now == 1041
-                        || now == 1061
-                        || now == 1081
-                        || now == 1101
-                        || now == 1121
-                        || now == 1141
-                        || now == 1161
-                        || now == 1181)
-                    {
-                        assert!(
-                            !link3.is_available(),
-                            "Storage cap reached at timestep {now}"
-                        );
-                    }
+                    assert!(
+                        !link3.is_available(),
+                        "Storage cap reached at timestep {now}"
+                    );
                 } else {
                     assert!(
                         link2.offers_veh(now).is_none(),

--- a/rust_qsim/src/simulation/network/storage_cap.rs
+++ b/rust_qsim/src/simulation/network/storage_cap.rs
@@ -23,10 +23,15 @@ impl StorageCapacityDefinition {
     ) -> Self {
         let flow_cap_s = capacity_h * sample_size / 3600.;
         let cap = length * perm_lanes * sample_size / effective_cell_size;
+
+        // set storage capacity to at least flow capacity. Otherwise, the flow capacity would never be fully used during `move_node`.
         let max_storage_cap = flow_cap_s.max(cap);
 
         let freespeed_travel_time = length / free_speed;
         let temp_storage_cap = freespeed_travel_time * flow_cap_s;
+
+        // set storage capacity to at least the freespeed travel time * flow capacity. Otherwise, the flow capacity would never be fully used,
+        // because vehicles would need at least need freespeed travel time to reach the end of the link.
         let adjusted = (max_storage_cap < temp_storage_cap).then_some(temp_storage_cap);
 
         Self {
@@ -39,6 +44,7 @@ impl StorageCapacityDefinition {
         self.qsim_override
     }
 
+    #[allow(dead_code)]
     pub(crate) fn original(&self) -> f64 {
         self.original
     }

--- a/rust_qsim/src/simulation/network/storage_cap.rs
+++ b/rust_qsim/src/simulation/network/storage_cap.rs
@@ -130,6 +130,7 @@ impl StorageCap {
         }
     }
 
+    #[cfg(test)]
     pub fn build(
         length: f64,
         perm_lanes: f64,

--- a/rust_qsim/src/simulation/network/storage_cap.rs
+++ b/rust_qsim/src/simulation/network/storage_cap.rs
@@ -1,3 +1,100 @@
+use crate::simulation::InternalAttributes;
+use crate::simulation::config;
+use crate::simulation::id::Id;
+use crate::simulation::scenario::network::{Link, Network};
+use nohash_hasher::IntMap;
+
+use super::STORAGE_CAPACITY_USED_IN_QSIM;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) struct StorageCapacityDefinition {
+    qsim_override: Option<f64>,
+    original: f64,
+}
+
+impl StorageCapacityDefinition {
+    pub(crate) fn build(
+        length: f64,
+        perm_lanes: f64,
+        capacity_h: f64,
+        sample_size: f64,
+        effective_cell_size: f64,
+        free_speed: f64,
+    ) -> Self {
+        let flow_cap_s = capacity_h * sample_size / 3600.;
+        let cap = length * perm_lanes * sample_size / effective_cell_size;
+        let max_storage_cap = flow_cap_s.max(cap);
+
+        let freespeed_travel_time = length / free_speed;
+        let temp_storage_cap = freespeed_travel_time * flow_cap_s;
+        let adjusted = (max_storage_cap < temp_storage_cap).then_some(temp_storage_cap);
+
+        Self {
+            qsim_override: adjusted,
+            original: max_storage_cap,
+        }
+    }
+
+    pub(crate) fn qsim_override(&self) -> Option<f64> {
+        self.qsim_override
+    }
+
+    pub(crate) fn original(&self) -> f64 {
+        self.original
+    }
+
+    pub(crate) fn max(&self) -> f64 {
+        self.qsim_override.unwrap_or(self.original)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LinkStorageCapacities {
+    capacities: IntMap<Id<Link>, StorageCapacityDefinition>,
+}
+
+impl LinkStorageCapacities {
+    pub fn from_network(network: &Network, config: &config::QSim) -> Self {
+        let effective_cell_size = network.effective_cell_size();
+        let capacities = network
+            .links()
+            .into_iter()
+            .map(|link| {
+                let definition = StorageCapacityDefinition::build(
+                    link.length,
+                    link.permlanes,
+                    link.capacity,
+                    config.sample_size,
+                    effective_cell_size,
+                    link.freespeed,
+                );
+                (link.id.clone(), definition)
+            })
+            .collect();
+
+        Self { capacities }
+    }
+
+    pub(crate) fn get(&self, link_id: &Id<Link>) -> &StorageCapacityDefinition {
+        self.capacities
+            .get(link_id)
+            .unwrap_or_else(|| panic!("No storage-capacity definition found for link {link_id}"))
+    }
+
+    pub(crate) fn attribute_overrides(&self) -> IntMap<Id<Link>, InternalAttributes> {
+        self.capacities
+            .iter()
+            .filter_map(|(link_id, definition)| {
+                definition.qsim_override().map(|adjusted| {
+                    let mut attributes = InternalAttributes::default();
+                    attributes.insert(STORAGE_CAPACITY_USED_IN_QSIM, adjusted);
+                    (link_id.clone(), attributes)
+                })
+            })
+            .collect()
+    }
+}
+
 /// StorageCap tracks changes in storage capacity for a link.
 /// First of all it stores the maximum available storage capacity for a link.
 /// Also, consumed and released capacity during a simulation time step is tracked
@@ -20,29 +117,39 @@ pub struct StorageCap {
 }
 
 impl StorageCap {
+    pub(crate) fn from_definition(definition: &StorageCapacityDefinition) -> Self {
+        Self {
+            max: definition.max(),
+            used: 0.0,
+        }
+    }
+
     pub fn build(
         length: f64,
         perm_lanes: f64,
         capacity_h: f64,
         sample_size: f64,
         effective_cell_size: f64,
+        free_speed: f64,
     ) -> Self {
-        let flow_cap_s = capacity_h * sample_size / 3600.;
-        let cap = length * perm_lanes * sample_size / effective_cell_size;
-        // storage capacity needs to be at least enough to handle the cap_per_time_step:
-        let max_storage_cap = flow_cap_s.max(cap);
-
-        // the original code contains more logic to increase storage capacity for links with a low
-        // free speed. Omit this for now, as we don't want to create a feature complete qsim
-
-        Self {
-            max: max_storage_cap,
-            used: 0.0,
-        }
+        let definition = StorageCapacityDefinition::build(
+            length,
+            perm_lanes,
+            capacity_h,
+            sample_size,
+            effective_cell_size,
+            free_speed,
+        );
+        Self::from_definition(&definition)
     }
 
     pub fn used(&self) -> f64 {
         self.used
+    }
+
+    #[cfg(test)]
+    pub(crate) fn max(&self) -> f64 {
+        self.max
     }
 
     /// Consumes storage capacity on a link
@@ -71,18 +178,66 @@ impl StorageCap {
 
 #[cfg(test)]
 mod test {
-    use crate::simulation::network::storage_cap::StorageCap;
+    use crate::simulation::config;
+    use crate::simulation::id::Id;
+    use crate::simulation::network::STORAGE_CAPACITY_USED_IN_QSIM;
+    use crate::simulation::network::storage_cap::{
+        LinkStorageCapacities, StorageCap, StorageCapacityDefinition,
+    };
+    use crate::simulation::scenario::Coordinate;
+    use crate::simulation::scenario::network::{Link, Network, Node};
+    use macros::deterministic_id_test;
 
     #[test]
-    fn init_default() {
-        let cap = StorageCap::build(100., 3., 1., 0.2, 7.5);
+    fn storage_capacity_definition_without_adjustment() {
+        let cap = StorageCap::build(100., 3., 1., 0.2, 7.5, 10.);
         assert_eq!(8., cap.max);
     }
 
     #[test]
-    fn init_large_capacity() {
-        let cap = StorageCap::build(100., 3., 360000., 0.2, 7.5);
-        // we expect a storage size of 20. because it the flow cap/s is 20 (36000 * 0.2 / 3600)
-        assert_eq!(20., cap.max);
+    fn storage_capacity_definition_with_freespeed_adjustment() {
+        let definition = StorageCapacityDefinition::build(100., 3., 360000., 0.2, 7.5, 10.);
+        assert_eq!(Some(200.), definition.qsim_override());
+        assert_eq!(20., definition.original());
+    }
+
+    #[test]
+    fn storage_capacity_definition_does_not_adjust_equal_capacity() {
+        let definition = StorageCapacityDefinition::build(100., 3., 360000., 0.2, 7.5, 100.);
+        assert_eq!(None, definition.qsim_override());
+        assert_eq!(20., definition.original());
+    }
+
+    #[deterministic_id_test]
+    fn storage_capacity_catalog_maps_adjusted_capacity_to_link_attribute() {
+        let mut network = Network::new();
+        let from = Node::new(Id::create("from"), Coordinate::default(), 0, 1);
+        let to = Node::new(Id::create("to"), Coordinate::default(), 0, 1);
+        let link_id = Id::create("link");
+        let mut link = Link::new_with_default(link_id.clone(), &from, &to);
+        link.length = 100.;
+        link.capacity = 360000.;
+        link.freespeed = 10.;
+        link.permlanes = 3.;
+        network.add_node(from);
+        network.add_node(to);
+        network.add_link(link);
+
+        let mut qsim = config::QSim::default();
+        qsim.sample_size = 0.2;
+        let capacities = LinkStorageCapacities::from_network(&network, &qsim);
+
+        assert_eq!(Some(200.), capacities.get(&link_id).qsim_override());
+        assert_eq!(
+            Some(200.),
+            capacities.attribute_overrides()[&link_id].get::<f64>(STORAGE_CAPACITY_USED_IN_QSIM)
+        );
+        assert_eq!(
+            None,
+            network
+                .get_link(&link_id)
+                .attributes
+                .get::<f64>(STORAGE_CAPACITY_USED_IN_QSIM)
+        );
     }
 }

--- a/rust_qsim/src/simulation/network/stuck_timer.rs
+++ b/rust_qsim/src/simulation/network/stuck_timer.rs
@@ -15,15 +15,8 @@ impl StuckTimer {
         }
     }
 
-    pub fn start(&self, now: impl Into<Tick>) {
-        let now = now.into();
-        if self.timer_started.get().is_none() {
-            self.timer_started.replace(Some(now));
-        }
-    }
-
-    pub fn reset(&self) {
-        self.timer_started.replace(None);
+    pub fn restart(&self, now: impl Into<Tick>) {
+        self.timer_started.replace(Some(now.into()));
     }
 
     pub fn is_stuck(&self, now: impl Into<Tick>) -> bool {
@@ -49,36 +42,25 @@ mod tests {
     }
 
     #[test]
-    fn start() {
+    fn restart() {
         let timer = StuckTimer::new(Tick::new(42));
 
-        timer.start(Tick::new(1));
-        timer.start(Tick::new(2));
+        timer.restart(Tick::new(1));
+        timer.restart(Tick::new(2));
 
         assert!(timer.timer_started.get().is_some());
-        assert_eq!(Tick::new(1), timer.timer_started.get().unwrap());
-    }
-
-    #[test]
-    fn reset() {
-        let timer = StuckTimer::new(Tick::new(42));
-
-        timer.start(Tick::new(17));
-        assert!(timer.timer_started.get().is_some());
-
-        timer.reset();
-        assert!(timer.timer_started.get().is_none());
+        assert_eq!(Tick::new(2), timer.timer_started.get().unwrap());
     }
 
     #[test]
     fn is_stuck() {
         let timer = StuckTimer::new(Tick::new(42));
 
-        timer.start(Tick::new(17));
+        timer.restart(Tick::new(17));
         assert!(!timer.is_stuck(Tick::new(18)));
         assert!(timer.is_stuck(Tick::new(17 + 42)));
 
-        timer.reset();
+        timer.restart(Tick::new(18));
         assert!(!timer.is_stuck(Tick::new(17 + 42)));
     }
 }

--- a/rust_qsim/src/simulation/network/stuck_timer.rs
+++ b/rust_qsim/src/simulation/network/stuck_timer.rs
@@ -1,27 +1,26 @@
 use crate::simulation::time::Tick;
-use std::cell::Cell;
 
 #[derive(Debug, Clone)]
 pub struct StuckTimer {
-    timer_started: Cell<Option<Tick>>,
+    timer_started: Option<Tick>,
     stuck_threshold: Tick,
 }
 
 impl StuckTimer {
     pub fn new(stuck_threshold: Tick) -> Self {
         StuckTimer {
-            timer_started: Cell::new(None),
+            timer_started: None,
             stuck_threshold,
         }
     }
 
-    pub fn restart(&self, now: impl Into<Tick>) {
-        self.timer_started.replace(Some(now.into()));
+    pub fn restart(&mut self, now: impl Into<Tick>) {
+        self.timer_started = Some(now.into());
     }
 
     pub fn is_stuck(&self, now: impl Into<Tick>) -> bool {
         let now = now.into();
-        if let Some(time) = self.timer_started.get() {
+        if let Some(time) = self.timer_started {
             now - time >= self.stuck_threshold
         } else {
             false
@@ -37,24 +36,24 @@ mod tests {
     #[test]
     fn init() {
         let timer = StuckTimer::new(Tick::new(42));
-        assert!(timer.timer_started.get().is_none());
+        assert!(timer.timer_started.is_none());
         assert_eq!(Tick::new(42), timer.stuck_threshold);
     }
 
     #[test]
     fn restart() {
-        let timer = StuckTimer::new(Tick::new(42));
+        let mut timer = StuckTimer::new(Tick::new(42));
 
         timer.restart(Tick::new(1));
         timer.restart(Tick::new(2));
 
-        assert!(timer.timer_started.get().is_some());
-        assert_eq!(Tick::new(2), timer.timer_started.get().unwrap());
+        assert!(timer.timer_started.is_some());
+        assert_eq!(Tick::new(2), timer.timer_started.unwrap());
     }
 
     #[test]
     fn is_stuck() {
-        let timer = StuckTimer::new(Tick::new(42));
+        let mut timer = StuckTimer::new(Tick::new(42));
 
         timer.restart(Tick::new(17));
         assert!(!timer.is_stuck(Tick::new(18)));

--- a/rust_qsim/src/simulation/population/agent_source.rs
+++ b/rust_qsim/src/simulation/population/agent_source.rs
@@ -129,6 +129,7 @@ mod tests {
     use crate::simulation::scenario::{
         Coordinate, MobsimScenarioPartition, PopulationShard, ScenarioCore,
     };
+    use macros::deterministic_id_test;
     use std::collections::HashMap;
     use std::sync::Arc;
 
@@ -169,7 +170,7 @@ mod tests {
         assert_eq!(Arc::strong_count(&dyn_source), 2);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn population_agent_source_consumes_owned_population_shard() {
         let core = empty_partition_core();
         let population = Population::from_persons(vec![person("person-1")]);

--- a/rust_qsim/src/simulation/population/agent_source.rs
+++ b/rust_qsim/src/simulation/population/agent_source.rs
@@ -120,7 +120,6 @@ mod tests {
     use super::{AgentSet, AgentSource, DynAgentSource, IntoDynAgentSource, PopulationAgentSource};
     use crate::simulation::config::Config;
     use crate::simulation::id::Id;
-    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::sim_network::SimNetworkPartition;
     use crate::simulation::scenario::network::{Link, Network};
     use crate::simulation::scenario::population::{
@@ -185,14 +184,7 @@ mod tests {
     fn empty_partition_core() -> MobsimScenarioPartition {
         let config = Arc::new(Config::default());
         let network = Arc::new(Network::new());
-        let storage_capacities = LinkStorageCapacities::from_network(&network, config.qsim());
-        let network_partition = SimNetworkPartition::from_network(
-            &network,
-            &storage_capacities,
-            0,
-            config.qsim(),
-            config.computational_setup().random_seed,
-        );
+        let network_partition = SimNetworkPartition::from_network_for_test(&network, 0, &config);
         MobsimScenarioPartition {
             rank: 0,
             scenario: ScenarioCore {

--- a/rust_qsim/src/simulation/population/agent_source.rs
+++ b/rust_qsim/src/simulation/population/agent_source.rs
@@ -120,6 +120,7 @@ mod tests {
     use super::{AgentSet, AgentSource, DynAgentSource, IntoDynAgentSource, PopulationAgentSource};
     use crate::simulation::config::Config;
     use crate::simulation::id::Id;
+    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::network::sim_network::SimNetworkPartition;
     use crate::simulation::scenario::network::{Link, Network};
     use crate::simulation::scenario::population::{
@@ -184,8 +185,10 @@ mod tests {
     fn empty_partition_core() -> MobsimScenarioPartition {
         let config = Arc::new(Config::default());
         let network = Arc::new(Network::new());
+        let storage_capacities = LinkStorageCapacities::from_network(&network, config.qsim());
         let network_partition = SimNetworkPartition::from_network(
             &network,
+            &storage_capacities,
             0,
             config.qsim(),
             config.computational_setup().random_seed,

--- a/rust_qsim/src/simulation/random.rs
+++ b/rust_qsim/src/simulation/random.rs
@@ -21,7 +21,7 @@ pub fn get_rng<H: Hash>(base_seed: u64, hash: H) -> SmallRng {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::Rng;
+    use rand::RngExt;
 
     #[test]
     fn test_random_generator_deterministic() {

--- a/rust_qsim/src/simulation/replanning/mod.rs
+++ b/rust_qsim/src/simulation/replanning/mod.rs
@@ -530,15 +530,16 @@ mod tests {
     use crate::simulation::config::{Replanning, StrategySetting};
     use crate::simulation::id::Id;
     use crate::simulation::scenario::population::{InternalPerson, InternalPlan};
+    use macros::deterministic_id_test;
 
-    #[test]
+    #[deterministic_id_test]
     fn keep_last_selector_returns_selected_plan_index() {
         let person = person_with_scores([Some(1.0), Some(2.0)]);
 
         assert_eq!(0, KeepLastSelector.select(&person, &context()));
     }
 
-    #[test]
+    #[deterministic_id_test]
     #[should_panic(expected = "KeepLastSelector could not find a selected plan.")]
     fn keep_last_selector_panics_without_selected_plan() {
         let mut person = person_with_scores([Some(1.0), Some(2.0)]);
@@ -549,7 +550,7 @@ mod tests {
         KeepLastSelector.select(&person, &context());
     }
 
-    #[test]
+    #[deterministic_id_test]
     #[should_panic(expected = "KeepLastSelector found multiple selected plans.")]
     fn keep_last_selector_panics_with_multiple_selected_plans() {
         let mut person = person_with_scores([Some(1.0), Some(2.0)]);
@@ -558,14 +559,14 @@ mod tests {
         KeepLastSelector.select(&person, &context());
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn worst_selector_treats_missing_score_as_worst() {
         let person = person_with_scores([Some(1.0), None, Some(-5.0)]);
 
         assert_eq!(1, WorstScoreSelector.select(&person, &context()));
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn worst_selector_prefers_removing_unselected_plans() {
         let mut person = person_with_scores([Some(-100.0), Some(1.0)]);
         person.plans_mut()[0].selected = true;
@@ -574,7 +575,7 @@ mod tests {
         assert_eq!(1, WorstScoreSelector.select(&person, &context()));
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn default_selectors_create_generic_strategies_with_matching_names() {
         for selector in [
             DefaultSelector::KeepLastSelected,
@@ -587,7 +588,7 @@ mod tests {
         }
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn random_selector_is_deterministic_for_same_context() {
         let person = person_with_scores([Some(1.0), Some(2.0), Some(3.0)]);
         let context = context();
@@ -599,7 +600,7 @@ mod tests {
         assert!(first < person.plans().len());
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn config_manager_uses_memory_limit_and_removal_selector() {
         let replanning = Replanning {
             max_agent_plan_memory: 1,
@@ -615,7 +616,7 @@ mod tests {
         assert_eq!(Some(1.0), person.plans()[0].score);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn config_manager_groups_strategy_weights_by_subpopulation() {
         let replanning = Replanning {
             strategy_settings: vec![
@@ -649,7 +650,7 @@ mod tests {
         assert_eq!(0.7, freight_weights.entries[0].weight);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn innovation_filter_keeps_selectors_and_excludes_default_strategies() {
         let replanning = Replanning {
             strategy_settings: vec![
@@ -681,7 +682,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn default_strategy_is_named_generic_keep_last_selected() {
         let manager = StrategyManager::default();
         let strategy_name = Id::create(DefaultSelector::KeepLastSelected.as_str());
@@ -696,7 +697,7 @@ mod tests {
         assert_eq!(strategy.name(), &default_weight.strategy_name);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn generic_strategy_without_modules_does_not_copy_plan() {
         let strategy = GenericPlanStrategy {
             name: Id::create("KeepLastSelected"),
@@ -712,7 +713,7 @@ mod tests {
         assert_eq!(Some(1.0), person.plans()[0].score);
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn generic_strategy_with_modules_copies_plan_and_runs_modules_on_copy() {
         let strategy = GenericPlanStrategy {
             name: Id::create("ReRoute"),

--- a/rust_qsim/src/simulation/replanning/mod.rs
+++ b/rust_qsim/src/simulation/replanning/mod.rs
@@ -4,7 +4,7 @@ use crate::simulation::random::get_rng;
 use crate::simulation::scenario::population::{DEFAULT_SUBPOPULATION, InternalPerson, Population};
 use ahash::HashMap;
 use derive_builder::Builder;
-use rand::Rng;
+use rand::RngExt;
 use rayon::prelude::*;
 use std::fmt;
 use std::str::FromStr;

--- a/rust_qsim/src/simulation/replanning/routing/a_star_core.rs
+++ b/rust_qsim/src/simulation/replanning/routing/a_star_core.rs
@@ -154,12 +154,12 @@ impl<'a> LandmarkCalcAStarActions<'a> {
 }
 
 impl AStarActions for LandmarkCalcAStarActions<'_> {
-    /// when called to track parents, this implementation does nothing
-    fn set_parent_link_opt(&mut self, _child: NodeIndex, _parent_link: LinkIndex) {}
     /// this implementation will never return reached_end==true, since there is no to-node
     fn reached_end(&self, _current_node: NodeIndex) -> bool {
         false
     }
+    /// when called to track parents, this implementation does nothing
+    fn set_parent_link_opt(&mut self, _child: NodeIndex, _parent_link: LinkIndex) {}
     /// returns a DisutilityToAllWithoutParents result.
     fn build_result(
         self,
@@ -268,11 +268,7 @@ impl AStarActions for RoutingAStarActions<'_> {
         // We always return the arrival time at the to-node, regardless of whether the algorithm
         // reached it or not. Since if it didn't, the arrival time there will be SimTime::max(),
         // which is reasonable to return.
-        // Note that it can be that the disutility to the to-node is infinity, but a finite time is
-        // returned as travel time. This case could occur if the to-node is connected to a visited
-        // node via a link with finite travel time but infinite travel disutility.
 
-        // unwrap is okay, since the method will always return Some() in this implementation
         let current_arrival_time = self.get_arrival_time_at_node_opt(self.to_node).unwrap();
 
         // subtract departure time to get the actual travel time

--- a/rust_qsim/src/simulation/replanning/routing/alt_landmark_data.rs
+++ b/rust_qsim/src/simulation/replanning/routing/alt_landmark_data.rs
@@ -76,7 +76,7 @@ impl AltLandmarkData {
             DEFAULT_NUMBER_OF_LANDMARKS
         };
         //TODO do not choose random landmarks
-        (0..graph.num_nodes()).choose_multiple(&mut StdRng::seed_from_u64(42), number_of_landmarks)
+        (0..graph.num_nodes()).sample(&mut StdRng::seed_from_u64(42), number_of_landmarks)
     }
 
     /// Calculate travel disutilities from given list of landmarks to all other nodes in the graph,

--- a/rust_qsim/src/simulation/replanning/routing/least_cost_path_calculator.rs
+++ b/rust_qsim/src/simulation/replanning/routing/least_cost_path_calculator.rs
@@ -13,7 +13,7 @@ pub type Disutility = f64;
 /// Travel time function, mapping any network link to a travel time, depending on the departure time
 /// and optionally the person and vehicle.
 pub trait TravelTime: Debug + Send + Sync {
-    /// get travel time of given link at given time, optionally for a specific person and vehicle
+    /// get travel time of a given link at a given time, optionally for a specific person and vehicle
     fn travel_time(
         &self,
         link: &Link,

--- a/rust_qsim/src/simulation/replanning/routing/network_routing.rs
+++ b/rust_qsim/src/simulation/replanning/routing/network_routing.rs
@@ -176,7 +176,8 @@ impl NetworkRoutingModule {
                 })?
         };
 
-        let elements = self.path_to_elements(path, &from, &to, &self.mode, request.vehicle);
+        let elements =
+            vec![self.path_to_elements(path, &from, &to, &self.mode, request.vehicle, now)];
         let time =
             TimeInterpretation::decide_on_elements_end_time(&elements, &now).ok_or_else(|| {
                 RoutingError::MissingEndTime {
@@ -194,7 +195,26 @@ impl NetworkRoutingModule {
         to: &Id<Link>,
         mode: &Id<String>,
         vehicle: Option<&InternalVehicle>,
-    ) -> Vec<InternalPlanElement> {
+        now: SimTime,
+    ) -> InternalPlanElement {
+        if from == to {
+            // If from and to are the same, we build a dummy node.
+            let generic = InternalGenericRoute::new(
+                from.clone(),
+                to.clone(),
+                Some(Duration::from_nanos(0)),
+                Some(0.),
+                vehicle.map(|v| v.id().clone()),
+            );
+            let net_route = InternalNetworkRoute::new(generic, vec![from.clone()]);
+            return InternalPlanElement::Leg(InternalLeg::new(
+                InternalRoute::Network(net_route),
+                mode.external(),
+                Duration::from_secs(0),
+                Some(now),
+            ));
+        }
+
         let mut route = Vec::with_capacity(path.path.len() + 2);
         route.push(from.clone());
         if from != to {
@@ -204,7 +224,16 @@ impl NetworkRoutingModule {
 
         let start = route.first().unwrap().clone();
         let end = route.last().unwrap().clone();
-        let time = path.travel_time;
+
+        // Correct travel time: the path doesn't contain the last link. Manually added here.
+        let to_link = self.scenario.network.get_link(to);
+        let vehicle_speed = if let Some(v) = vehicle {
+            v.max_v
+        } else {
+            f64::MAX
+        };
+        let max_speed = to_link.freespeed.min(vehicle_speed);
+        let trav_time = path.travel_time + Duration::from_secs_f64(to_link.length / max_speed);
 
         // calculate the distance of the path. Ignore the first link (since vehicle starts at the very end).
         let distance: f64 = route[1..]
@@ -216,15 +245,15 @@ impl NetworkRoutingModule {
         let generic = InternalGenericRoute::new(
             start,
             end,
-            Some(time),
+            Some(trav_time),
             Some(distance),
             vehicle.map(|v| v.id().clone()),
         );
 
         let net_route = InternalNetworkRoute::new(generic, route);
         let route = InternalRoute::Network(net_route);
-        let leg = InternalLeg::new(route, mode.external(), path.travel_time, None);
-        vec![InternalPlanElement::Leg(leg)]
+        let leg = InternalLeg::new(route, mode.external(), trav_time, Some(now));
+        InternalPlanElement::Leg(leg)
     }
 
     fn create_interaction_activity(

--- a/rust_qsim/src/simulation/replanning/routing/travel_time_collector.rs
+++ b/rust_qsim/src/simulation/replanning/routing/travel_time_collector.rs
@@ -1,117 +1,303 @@
 use crate::simulation::events::{
-    EventHandlerRegisterFn, LinkEnterEvent, LinkLeaveEvent, PersonLeavesVehicleEvent,
+    LinkEnterEvent, LinkLeaveEvent, PersonLeavesVehicleEvent, VehicleEntersTrafficEvent,
+    VehicleLeavesTrafficEvent,
 };
 use crate::simulation::id::Id;
 use crate::simulation::scenario::network::Link;
 use crate::simulation::scenario::vehicles::InternalVehicle;
 use crate::simulation::time::SimTime;
-use nohash_hasher::IntMap;
-use std::cell::RefCell;
-use std::collections::HashMap;
-use std::rc::Rc;
+use nohash_hasher::{IntMap, IntSet};
 use std::time::Duration;
 
-pub struct TravelTimeCollector {
-    travel_times_by_link: HashMap<Id<Link>, Vec<Duration>>,
-    cache_enter_time_by_vehicle: IntMap<Id<InternalVehicle>, SimTime>,
+#[derive(Clone, Debug)]
+struct ActiveLinkEnter {
+    link: Id<Link>,
+    time: SimTime,
 }
 
-impl Default for TravelTimeCollector {
-    fn default() -> Self {
-        Self::new()
-    }
+#[derive(Clone, Debug, Default)]
+struct TravelTimeBin {
+    mean_nanos: f64,
+    count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TravelTimeGetter {
+    Average,
+    LinearInterpolation,
+}
+
+#[derive(Debug)]
+pub struct TravelTimeCalculator {
+    modes: IntSet<Id<String>>,
+    bin_size: Duration,
+    num_bins: usize,
+    active_link_enters_by_vehicle: IntMap<Id<InternalVehicle>, ActiveLinkEnter>,
+    ignored_vehicles: IntSet<Id<InternalVehicle>>,
+    travel_time_bins_by_link: IntMap<Id<Link>, Vec<TravelTimeBin>>,
+    consolidated_travel_times_by_link: IntMap<Id<Link>, Vec<Duration>>,
+    // Links that have been updated since the last time we consolidated travel times.
+    dirty_links: IntSet<Id<Link>>,
 }
 
 #[allow(dead_code)]
-impl TravelTimeCollector {
-    pub fn new() -> Self {
-        TravelTimeCollector {
-            travel_times_by_link: HashMap::new(),
-            cache_enter_time_by_vehicle: IntMap::default(),
+impl TravelTimeCalculator {
+    pub fn new(modes: IntSet<Id<String>>, bin_size: Duration, max_time: Duration) -> Self {
+        assert!(
+            bin_size > Duration::ZERO,
+            "travel time bin size must be greater than zero"
+        );
+
+        let num_bins = ((max_time.as_nanos() / bin_size.as_nanos()) + 1)
+            .try_into()
+            .expect("number of travel time bins does not fit into usize");
+
+        TravelTimeCalculator {
+            modes,
+            bin_size,
+            num_bins,
+            active_link_enters_by_vehicle: IntMap::default(),
+            ignored_vehicles: IntSet::default(),
+            travel_time_bins_by_link: IntMap::default(),
+            consolidated_travel_times_by_link: IntMap::default(),
+            dirty_links: IntSet::default(),
         }
     }
 
-    fn process_link_enter_event(&mut self, event: &LinkEnterEvent) {
-        // link enter events will always be stored
-        let time = event.time;
-        self.cache_enter_time_by_vehicle
-            .insert(event.vehicle.clone(), time);
-    }
-
-    fn process_link_leave_event(&mut self, event: &LinkLeaveEvent) {
-        // remove traffic information of link enter and compute travel time (assumes that a vehicle will leave a link before it enters the same again)
-        // if it's None, the LinkLeaveEvent is the begin of a leg, thus no travel time can be computed
-        let time = event.time;
-        if let Some(t) = self.cache_enter_time_by_vehicle.remove(&event.vehicle) {
-            self.travel_times_by_link
-                .entry(event.link.clone())
-                .or_default()
-                .push(time.duration_since(t))
+    pub fn process_vehicle_enters_traffic_event(&mut self, event: &VehicleEntersTrafficEvent) {
+        if self.modes.is_empty() || self.modes.contains(&event.network_mode) {
+            self.ignored_vehicles.remove(&event.vehicle);
+        } else {
+            // If the mode is not in the set of modes we are interested in, we ignore the vehicle.
+            self.ignored_vehicles.insert(event.vehicle.clone());
+            self.active_link_enters_by_vehicle.remove(&event.vehicle);
         }
     }
 
-    fn process_person_leaves_vehicle_event(&mut self, event: &PersonLeavesVehicleEvent) {
-        self.cache_enter_time_by_vehicle.remove(&event.vehicle);
+    pub fn process_link_enter_event(&mut self, event: &LinkEnterEvent) {
+        if self.ignored_vehicles.contains(&event.vehicle) {
+            return;
+        }
+
+        self.active_link_enters_by_vehicle.insert(
+            event.vehicle.clone(),
+            ActiveLinkEnter {
+                link: event.link.clone(),
+                time: event.time,
+            },
+        );
     }
 
-    fn get_travel_time_of_link(&self, link: &Id<Link>) -> Option<u32> {
-        match self.travel_times_by_link.get(link) {
-            None => None,
-            Some(travel_times) => {
-                let sum: Duration = travel_times.iter().copied().sum();
-                let len = travel_times.len();
-                Some((sum / (len as u32)).as_secs() as u32)
+    pub fn process_link_leave_event(&mut self, event: &LinkLeaveEvent) {
+        let Some(active_enter) = self.active_link_enters_by_vehicle.remove(&event.vehicle) else {
+            // Return if vehicle didn't enter link before, i.e., this is the first link leave after activity.
+            return;
+        };
+
+        let travel_time = event.time.duration_since(active_enter.time);
+        let time_slot = self.time_slot(active_enter.time);
+        let bins = self
+            .travel_time_bins_by_link
+            .entry(active_enter.link.clone())
+            .or_insert_with(|| vec![TravelTimeBin::default(); self.num_bins]);
+
+        let bin = &mut bins[time_slot];
+        let next_count = bin.count + 1;
+        bin.mean_nanos = ((bin.mean_nanos * bin.count as f64) + duration_to_nanos_f64(travel_time))
+            / next_count as f64;
+        bin.count = next_count;
+
+        self.dirty_links.insert(active_enter.link);
+    }
+
+    pub fn process_vehicle_leaves_traffic_event(&mut self, event: &VehicleLeavesTrafficEvent) {
+        self.clear_vehicle_state(&event.vehicle);
+    }
+
+    pub fn get_link_travel_time(
+        &mut self,
+        link: &Link,
+        now: SimTime,
+        vehicle: Option<&InternalVehicle>,
+        getter: TravelTimeGetter,
+    ) -> Duration {
+        let time_slot = self.time_slot(now);
+        let bin_size = self.bin_size;
+        let travel_times = self.consolidated_travel_times(link);
+        let observed = match getter {
+            TravelTimeGetter::Average => travel_times[time_slot],
+            TravelTimeGetter::LinearInterpolation => {
+                interpolated_travel_time(travel_times, now, bin_size)
+            }
+        };
+
+        if let Some(vehicle) = vehicle {
+            if vehicle.max_v.is_finite() && vehicle.max_v > 0.0 {
+                return observed.max(travel_time_from_speed(link.length, vehicle.max_v));
             }
         }
+
+        observed
     }
 
-    fn get_travel_times(&self) -> HashMap<Id<Link>, u32> {
-        self.travel_times_by_link
-            .keys()
-            .map(|id| (id.clone(), self.get_travel_time_of_link(id)))
-            .filter(|(_, travel_time)| travel_time.is_some())
-            .map(|(id, travel_time)| (id, travel_time.unwrap()))
-            .collect::<HashMap<Id<Link>, u32>>()
+    pub fn flush(&mut self) {
+        self.travel_time_bins_by_link = IntMap::default();
+        self.consolidated_travel_times_by_link = IntMap::default();
+        self.dirty_links = IntSet::default();
     }
 
-    fn flush(&mut self) {
-        // Collected travel times will be dropped, but cached values not.
-        // Vehicles of cached values haven't left the corresponding links yet.
-        // A travel time of a link is considered when a vehicle leaves the link.
-        self.travel_times_by_link = HashMap::new();
+    fn clear_vehicle_state(&mut self, vehicle: &Id<InternalVehicle>) {
+        self.active_link_enters_by_vehicle.remove(vehicle);
+        self.ignored_vehicles.remove(vehicle);
     }
 
-    pub fn register() -> Box<EventHandlerRegisterFn> {
-        Box::new(move |e| {
-            let ttc = Rc::new(RefCell::new(TravelTimeCollector::new()));
-
-            let ttc1 = ttc.clone();
-            let ttc2 = ttc.clone();
-
-            e.on::<LinkEnterEvent, _>(move |e| {
-                ttc.borrow_mut().process_link_enter_event(e);
-            });
-            e.on::<LinkLeaveEvent, _>(move |e| {
-                ttc1.borrow_mut().process_link_leave_event(e);
-            });
-            e.on::<PersonLeavesVehicleEvent, _>(move |e| {
-                ttc2.borrow_mut().process_person_leaves_vehicle_event(e);
-            })
-        })
+    /// Returns the index of the bin corresponding to the time.
+    fn time_slot(&self, time: SimTime) -> usize {
+        let slot = time.as_duration().as_nanos() / self.bin_size.as_nanos();
+        let slot = usize::try_from(slot).unwrap_or(usize::MAX);
+        slot.min(self.num_bins - 1)
     }
+
+    fn consolidated_travel_times(&mut self, link: &Link) -> &[Duration] {
+        let needs_update = self.dirty_links.remove(&link.id)
+            || !self
+                .consolidated_travel_times_by_link
+                .contains_key(&link.id);
+
+        if needs_update {
+            let consolidated = self.build_consolidated_travel_times(link);
+            self.consolidated_travel_times_by_link
+                .insert(link.id.clone(), consolidated);
+        }
+
+        self.consolidated_travel_times_by_link
+            .get(&link.id)
+            .expect("consolidated travel times must exist after update")
+    }
+
+    fn build_consolidated_travel_times(&self, link: &Link) -> Vec<Duration> {
+        let freespeed_travel_time = travel_time_from_speed(link.length, link.freespeed);
+        let mut result = vec![freespeed_travel_time; self.num_bins];
+
+        if let Some(bins) = self.travel_time_bins_by_link.get(&link.id) {
+            for (i, bin) in bins.iter().enumerate() {
+                if bin.count > 0 {
+                    result[i] = Duration::from_secs_f64(bin.mean_nanos / 1_000_000_000.0);
+                }
+            }
+        }
+
+        for i in 1..result.len() {
+            let lower_bound = result[i - 1].saturating_sub(self.bin_size);
+            if result[i] < lower_bound {
+                result[i] = lower_bound;
+            }
+        }
+
+        result
+    }
+}
+
+fn duration_to_nanos_f64(duration: Duration) -> f64 {
+    duration.as_secs_f64() * 1_000_000_000.0
+}
+
+fn travel_time_from_speed(length: f64, speed: f64) -> Duration {
+    assert!(
+        speed.is_finite() && speed > 0.0,
+        "speed must be finite and greater than zero"
+    );
+    Duration::from_secs_f64(length / speed)
+}
+
+fn interpolated_travel_time(
+    travel_times: &[Duration],
+    now: SimTime,
+    bin_size: Duration,
+) -> Duration {
+    if travel_times.len() == 1 {
+        return travel_times[0];
+    }
+
+    let bin_size_nanos = duration_to_nanos_f64(bin_size);
+    let now_nanos = duration_to_nanos_f64(now.as_duration());
+    let first_center = bin_size_nanos * 0.5;
+    let last_center = (travel_times.len() as f64 - 0.5) * bin_size_nanos;
+
+    if now_nanos <= first_center {
+        return travel_times[0];
+    }
+    if now_nanos >= last_center {
+        return *travel_times.last().unwrap();
+    }
+
+    let lower = ((now_nanos / bin_size_nanos) - 0.5).floor() as usize;
+    let upper = lower + 1;
+    let lower_center = (lower as f64 + 0.5) * bin_size_nanos;
+    let fraction = (now_nanos - lower_center) / bin_size_nanos;
+
+    let lower_nanos = duration_to_nanos_f64(travel_times[lower]);
+    let upper_nanos = duration_to_nanos_f64(travel_times[upper]);
+    Duration::from_secs_f64(
+        ((lower_nanos + ((upper_nanos - lower_nanos) * fraction)) / 1_000_000_000.0).max(0.0),
+    )
 }
 
 #[cfg(test)]
 mod test {
     use crate::simulation::InternalAttributes;
-    use crate::simulation::events::{LinkEnterEvent, LinkLeaveEvent, PersonLeavesVehicleEvent};
+    use crate::simulation::events::{
+        LinkEnterEvent, LinkLeaveEvent, PersonLeavesVehicleEvent, VehicleEntersTrafficEvent,
+        VehicleLeavesTrafficEvent,
+    };
     use crate::simulation::id::Id;
-    use crate::simulation::replanning::routing::travel_time_collector::TravelTimeCollector;
-    use crate::simulation::scenario::network::Link;
+    use crate::simulation::replanning::routing::travel_time_collector::{
+        TravelTimeCalculator, TravelTimeGetter,
+    };
+    use crate::simulation::scenario::network::{Link, Node};
     use crate::simulation::scenario::population::InternalPerson;
     use crate::simulation::scenario::vehicles::InternalVehicle;
     use crate::simulation::time::SimTime;
     use macros::deterministic_id_test;
+    use nohash_hasher::IntSet;
+    use std::time::Duration;
+
+    fn calculator(
+        modes: IntSet<Id<String>>,
+        bin_size_secs: u64,
+        max_time_secs: u64,
+    ) -> TravelTimeCalculator {
+        TravelTimeCalculator::new(
+            modes,
+            Duration::from_secs(bin_size_secs),
+            Duration::from_secs(max_time_secs),
+        )
+    }
+
+    fn link(id: &str, length: f64, freespeed: f64) -> Link {
+        Link {
+            id: Id::create(id),
+            from: Id::<Node>::create(&format!("{id}_from")),
+            to: Id::<Node>::create(&format!("{id}_to")),
+            length,
+            capacity: 3600.0,
+            freespeed,
+            permlanes: 1.0,
+            modes: IntSet::default(),
+            partition: 0,
+            attributes: InternalAttributes::default(),
+        }
+    }
+
+    fn vehicle(id: &str, max_v: f64) -> InternalVehicle {
+        InternalVehicle {
+            id: Id::create(id),
+            max_v,
+            pce: 1.0,
+            vehicle_type: Id::create("default"),
+            attributes: InternalAttributes::default(),
+        }
+    }
 
     fn link_enter_event(
         time: SimTime,
@@ -139,6 +325,42 @@ mod test {
         }
     }
 
+    fn vehicle_enters_traffic_event(
+        time: SimTime,
+        link: &Id<Link>,
+        person: &Id<InternalPerson>,
+        vehicle: &Id<InternalVehicle>,
+        network_mode: &Id<String>,
+    ) -> VehicleEntersTrafficEvent {
+        VehicleEntersTrafficEvent {
+            time,
+            vehicle: vehicle.clone(),
+            link: link.clone(),
+            person: person.clone(),
+            network_mode: network_mode.clone(),
+            relative_position: 1.0,
+            attributes: InternalAttributes::default(),
+        }
+    }
+
+    fn vehicle_leaves_traffic_event(
+        time: SimTime,
+        link: &Id<Link>,
+        person: &Id<InternalPerson>,
+        vehicle: &Id<InternalVehicle>,
+        network_mode: &Id<String>,
+    ) -> VehicleLeavesTrafficEvent {
+        VehicleLeavesTrafficEvent {
+            time,
+            vehicle: vehicle.clone(),
+            link: link.clone(),
+            person: person.clone(),
+            network_mode: network_mode.clone(),
+            relative_position: 1.0,
+            attributes: InternalAttributes::default(),
+        }
+    }
+
     fn person_leaves_vehicle_event(
         time: SimTime,
         person: &Id<InternalPerson>,
@@ -152,180 +374,310 @@ mod test {
         }
     }
 
-    #[deterministic_id_test]
-    fn test_one_vehicle() {
-        let link1 = Id::create("1");
-        let link2 = Id::create("2");
-        let vehicle1 = Id::create("1");
-
-        let mut collector = TravelTimeCollector::new();
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(1),
-            &link1,
-            &vehicle1,
-        ));
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::from_secs(2),
-            &link2,
-            &vehicle1,
-        ));
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(4),
-            &link2,
-            &vehicle1,
-        ));
-
-        assert_eq!(collector.get_travel_time_of_link(&link2), Some(2));
-        assert_eq!(collector.get_travel_time_of_link(&link1), None);
-        assert_eq!(collector.get_travel_times().keys().len(), 1);
-        assert_eq!(collector.get_travel_times().get(&link2), Some(&2u32));
-        assert_eq!(collector.cache_enter_time_by_vehicle.get(&vehicle1), None)
-    }
-
-    #[deterministic_id_test]
-    /// Tests travel time collection with two vehicles passing link 2.
-    /// Vehicle 1: 2s
-    /// Vehicle 2: 4s
-    fn test_two_vehicles() {
-        let link1 = Id::create("1");
-        let link2 = Id::create("2");
-        let vehicle1 = Id::create("1");
-        let vehicle2 = Id::create("2");
-        let vehicle3 = Id::create("3");
-
-        let mut collector = TravelTimeCollector::new();
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(1),
-            &link1,
-            &vehicle1,
-        ));
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::from_secs(2),
-            &link2,
-            &vehicle1,
-        ));
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::from_secs(3),
-            &link2,
-            &vehicle2,
-        ));
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(4),
-            &link2,
-            &vehicle1,
-        ));
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::from_secs(5),
-            &link2,
-            &vehicle3,
-        ));
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(7),
-            &link2,
-            &vehicle2,
-        ));
-
-        // The average travel time on link 2 is 3
-        assert_eq!(Some(3), collector.get_travel_time_of_link(&link2));
-        assert_eq!(None, collector.get_travel_time_of_link(&link1));
-
-        assert_eq!(collector.get_travel_times().keys().len(), 1);
-        assert_eq!(collector.get_travel_times().get(&link2), Some(&3u32));
-
-        // vehicle 1 and 2 have no cached traffic information
-        assert_eq!(collector.cache_enter_time_by_vehicle.get(&vehicle1), None);
-        assert_eq!(collector.cache_enter_time_by_vehicle.get(&vehicle2), None);
-
-        // vehicle 3 has cached traffic information
-        assert_eq!(
-            collector
-                .cache_enter_time_by_vehicle
-                .get(&vehicle3)
-                .unwrap(),
-            &SimTime::from_secs(5)
+    fn average_travel_time(
+        calculator: &mut TravelTimeCalculator,
+        link: &Link,
+        now_secs: u64,
+    ) -> Duration {
+        calculator.get_link_travel_time(
+            link,
+            SimTime::from_secs(now_secs),
+            None,
+            TravelTimeGetter::Average,
         )
     }
 
     #[deterministic_id_test]
-    /// Tests whether PersonLeavesVehicleEvent discards travel time
-    fn test_with_person_leaves_vehicle() {
-        let link1 = Id::create("1");
-        let vehicle1 = Id::create("1");
-        let person1 = Id::create("p1");
+    fn leave_without_enter_is_ignored_and_empty_link_uses_freespeed() {
+        let link = link("1", 100.0, 10.0);
+        let vehicle = vehicle("v1", 20.0);
+        let mut calculator = calculator(IntSet::default(), 10, 100);
 
-        let mut collector = TravelTimeCollector::new();
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::default(),
-            &link1,
-            &vehicle1,
-        ));
-        collector.process_person_leaves_vehicle_event(&person_leaves_vehicle_event(
-            SimTime::from_secs(2),
-            &person1,
-            &vehicle1,
-        ));
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(4),
-            &link1,
-            &vehicle1,
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(5),
+            &link.id,
+            &vehicle.id,
         ));
 
-        assert_eq!(collector.get_travel_time_of_link(&link1), None);
-        assert_eq!(collector.cache_enter_time_by_vehicle.get(&vehicle1), None);
+        assert_eq!(
+            Duration::from_secs(10),
+            average_travel_time(&mut calculator, &link, 0)
+        );
     }
 
     #[deterministic_id_test]
-    /// Tests whether PersonLeavesVehicleEvent discards travel time
-    fn test_with_person_leaves_vehicle_complex() {
-        let link1 = Id::create("1");
-        let link2 = Id::create("2");
-        let vehicle1 = Id::create("1");
-        let vehicle2 = Id::create("2");
-        let person1 = Id::create("p1");
+    fn records_travel_time_in_enter_time_slot() {
+        let link = link("1", 100.0, 100.0);
+        let vehicle = vehicle("v1", 20.0);
+        let mut calculator = calculator(IntSet::default(), 10, 100);
 
-        let mut collector = TravelTimeCollector::new();
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::default(),
-            &link1,
-            &vehicle1,
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(9),
+            &link.id,
+            &vehicle.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(14),
+            &link.id,
+            &vehicle.id,
         ));
 
-        //intermediate veh 2 enters link 1
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::from_secs(1),
-            &link1,
-            &vehicle2,
-        ));
-        collector.process_person_leaves_vehicle_event(&person_leaves_vehicle_event(
+        assert_eq!(
+            Duration::from_secs(5),
+            average_travel_time(&mut calculator, &link, 0)
+        );
+        assert_eq!(
+            Duration::from_secs(1),
+            average_travel_time(&mut calculator, &link, 10)
+        );
+    }
+
+    #[deterministic_id_test]
+    fn calculates_running_mean_per_link_and_slot() {
+        let link = link("1", 100.0, 100.0);
+        let vehicle1 = vehicle("v1", 20.0);
+        let vehicle2 = vehicle("v2", 20.0);
+        let mut calculator = calculator(IntSet::default(), 10, 100);
+
+        calculator.process_link_enter_event(&link_enter_event(
             SimTime::from_secs(2),
-            &person1,
-            &vehicle1,
+            &link.id,
+            &vehicle1.id,
         ));
-
-        //intermediate veh 2 leaves link 1
-        collector.process_link_leave_event(&link_leave_event(
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(4),
+            &link.id,
+            &vehicle1.id,
+        ));
+        calculator.process_link_enter_event(&link_enter_event(
             SimTime::from_secs(3),
-            &link1,
-            &vehicle2,
+            &link.id,
+            &vehicle2.id,
         ));
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(10),
-            &link1,
-            &vehicle1,
-        ));
-        collector.process_link_enter_event(&link_enter_event(
-            SimTime::from_secs(10),
-            &link2,
-            &vehicle1,
-        ));
-        collector.process_link_leave_event(&link_leave_event(
-            SimTime::from_secs(20),
-            &link2,
-            &vehicle1,
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(7),
+            &link.id,
+            &vehicle2.id,
         ));
 
-        assert_eq!(collector.get_travel_time_of_link(&link1), Some(2));
-        assert_eq!(collector.get_travel_time_of_link(&link2), Some(10));
-        assert_eq!(collector.cache_enter_time_by_vehicle.get(&vehicle1), None);
+        assert_eq!(
+            Duration::from_secs(3),
+            average_travel_time(&mut calculator, &link, 0)
+        );
+    }
+
+    #[deterministic_id_test]
+    fn clamps_enter_time_slot_to_max_time() {
+        let link = link("1", 100.0, 100.0);
+        let vehicle = vehicle("v1", 20.0);
+        let mut calculator = calculator(IntSet::default(), 10, 25);
+
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(99),
+            &link.id,
+            &vehicle.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(104),
+            &link.id,
+            &vehicle.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(5),
+            average_travel_time(&mut calculator, &link, 20)
+        );
+    }
+
+    #[deterministic_id_test]
+    fn filters_link_events_by_vehicle_network_mode() {
+        let link = link("1", 100.0, 100.0);
+        let person: Id<InternalPerson> = Id::create("p1");
+        let vehicle = vehicle("v1", 20.0);
+        let car: Id<String> = Id::create("car");
+        let bike: Id<String> = Id::create("bike");
+        let mut modes = IntSet::default();
+        modes.insert(car.clone());
+        let mut calculator = calculator(modes, 10, 100);
+
+        calculator.process_vehicle_enters_traffic_event(&vehicle_enters_traffic_event(
+            SimTime::from_secs(0),
+            &link.id,
+            &person,
+            &vehicle.id,
+            &bike,
+        ));
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(0),
+            &link.id,
+            &vehicle.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(9),
+            &link.id,
+            &vehicle.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(1),
+            average_travel_time(&mut calculator, &link, 0)
+        );
+
+        calculator.process_vehicle_enters_traffic_event(&vehicle_enters_traffic_event(
+            SimTime::from_secs(10),
+            &link.id,
+            &person,
+            &vehicle.id,
+            &car,
+        ));
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(10),
+            &link.id,
+            &vehicle.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(15),
+            &link.id,
+            &vehicle.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(5),
+            average_travel_time(&mut calculator, &link, 10)
+        );
+    }
+
+    #[deterministic_id_test]
+    fn vehicle_leaves_traffic_discards_active_enter() {
+        let link = link("1", 100.0, 100.0);
+        let person: Id<InternalPerson> = Id::create("p1");
+        let vehicle = vehicle("v1", 20.0);
+        let car: Id<String> = Id::create("car");
+        let mut calculator = calculator(IntSet::default(), 10, 100);
+
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(0),
+            &link.id,
+            &vehicle.id,
+        ));
+        calculator.process_vehicle_leaves_traffic_event(&vehicle_leaves_traffic_event(
+            SimTime::from_secs(2),
+            &link.id,
+            &person,
+            &vehicle.id,
+            &car,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(5),
+            &link.id,
+            &vehicle.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(1),
+            average_travel_time(&mut calculator, &link, 0)
+        );
+    }
+
+    #[deterministic_id_test]
+    fn consolidation_cascades_previous_bin_minus_bin_size() {
+        let link = link("1", 100.0, 100.0);
+        let vehicle = vehicle("v1", 20.0);
+        let mut calculator = calculator(IntSet::default(), 900, 3600);
+
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(0),
+            &link.id,
+            &vehicle.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(3000),
+            &link.id,
+            &vehicle.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(3000),
+            average_travel_time(&mut calculator, &link, 0)
+        );
+        assert_eq!(
+            Duration::from_secs(2100),
+            average_travel_time(&mut calculator, &link, 900)
+        );
+        assert_eq!(
+            Duration::from_secs(1200),
+            average_travel_time(&mut calculator, &link, 1800)
+        );
+        assert_eq!(
+            Duration::from_secs(300),
+            average_travel_time(&mut calculator, &link, 2700)
+        );
+    }
+
+    #[deterministic_id_test]
+    fn linear_interpolation_uses_neighboring_bin_midpoints() {
+        let link = link("1", 100.0, 100.0);
+        let vehicle1 = vehicle("v1", 20.0);
+        let vehicle2 = vehicle("v2", 20.0);
+        let mut calculator = calculator(IntSet::default(), 10, 100);
+
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(0),
+            &link.id,
+            &vehicle1.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(10),
+            &link.id,
+            &vehicle1.id,
+        ));
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(10),
+            &link.id,
+            &vehicle2.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(30),
+            &link.id,
+            &vehicle2.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(15),
+            calculator.get_link_travel_time(
+                &link,
+                SimTime::from_secs(10),
+                None,
+                TravelTimeGetter::LinearInterpolation,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn vehicle_max_speed_clamps_empirical_travel_time() {
+        let link = link("1", 100.0, 100.0);
+        let slow_vehicle = vehicle("v1", 10.0);
+        let mut calculator = calculator(IntSet::default(), 10, 100);
+
+        calculator.process_link_enter_event(&link_enter_event(
+            SimTime::from_secs(0),
+            &link.id,
+            &slow_vehicle.id,
+        ));
+        calculator.process_link_leave_event(&link_leave_event(
+            SimTime::from_secs(1),
+            &link.id,
+            &slow_vehicle.id,
+        ));
+
+        assert_eq!(
+            Duration::from_secs(10),
+            calculator.get_link_travel_time(
+                &link,
+                SimTime::from_secs(0),
+                Some(&slow_vehicle),
+                TravelTimeGetter::Average,
+            )
+        );
     }
 }

--- a/rust_qsim/src/simulation/replanning/routing/travel_time_collector.rs
+++ b/rust_qsim/src/simulation/replanning/routing/travel_time_collector.rs
@@ -1,6 +1,5 @@
 use crate::simulation::events::{
-    LinkEnterEvent, LinkLeaveEvent, PersonLeavesVehicleEvent, VehicleEntersTrafficEvent,
-    VehicleLeavesTrafficEvent,
+    LinkEnterEvent, LinkLeaveEvent, VehicleEntersTrafficEvent, VehicleLeavesTrafficEvent,
 };
 use crate::simulation::id::Id;
 use crate::simulation::scenario::network::Link;
@@ -21,6 +20,13 @@ struct TravelTimeBin {
     count: u64,
 }
 
+#[derive(Debug)]
+struct TravelTimeData {
+    travel_time_bins: Vec<TravelTimeBin>,
+    consolidated_travel_times: Option<Vec<Duration>>,
+    dirty: bool,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TravelTimeGetter {
     Average,
@@ -34,10 +40,7 @@ pub struct TravelTimeCalculator {
     num_bins: usize,
     active_link_enters_by_vehicle: IntMap<Id<InternalVehicle>, ActiveLinkEnter>,
     ignored_vehicles: IntSet<Id<InternalVehicle>>,
-    travel_time_bins_by_link: IntMap<Id<Link>, Vec<TravelTimeBin>>,
-    consolidated_travel_times_by_link: IntMap<Id<Link>, Vec<Duration>>,
-    // Links that have been updated since the last time we consolidated travel times.
-    dirty_links: IntSet<Id<Link>>,
+    travel_time_data_by_link: IntMap<Id<Link>, TravelTimeData>,
 }
 
 #[allow(dead_code)]
@@ -58,9 +61,7 @@ impl TravelTimeCalculator {
             num_bins,
             active_link_enters_by_vehicle: IntMap::default(),
             ignored_vehicles: IntSet::default(),
-            travel_time_bins_by_link: IntMap::default(),
-            consolidated_travel_times_by_link: IntMap::default(),
-            dirty_links: IntSet::default(),
+            travel_time_data_by_link: IntMap::default(),
         }
     }
 
@@ -96,18 +97,10 @@ impl TravelTimeCalculator {
 
         let travel_time = event.time.duration_since(active_enter.time);
         let time_slot = self.time_slot(active_enter.time);
-        let bins = self
-            .travel_time_bins_by_link
-            .entry(active_enter.link.clone())
-            .or_insert_with(|| vec![TravelTimeBin::default(); self.num_bins]);
-
-        let bin = &mut bins[time_slot];
-        let next_count = bin.count + 1;
-        bin.mean_nanos = ((bin.mean_nanos * bin.count as f64) + duration_to_nanos_f64(travel_time))
-            / next_count as f64;
-        bin.count = next_count;
-
-        self.dirty_links.insert(active_enter.link);
+        self.travel_time_data_by_link
+            .entry(active_enter.link)
+            .or_insert_with(|| TravelTimeData::new(self.num_bins))
+            .observe(time_slot, travel_time);
     }
 
     pub fn process_vehicle_leaves_traffic_event(&mut self, event: &VehicleLeavesTrafficEvent) {
@@ -123,13 +116,11 @@ impl TravelTimeCalculator {
     ) -> Duration {
         let time_slot = self.time_slot(now);
         let bin_size = self.bin_size;
-        let travel_times = self.consolidated_travel_times(link);
-        let observed = match getter {
-            TravelTimeGetter::Average => travel_times[time_slot],
-            TravelTimeGetter::LinearInterpolation => {
-                interpolated_travel_time(travel_times, now, bin_size)
-            }
-        };
+        let observed = self
+            .travel_time_data_by_link
+            .entry(link.id.clone())
+            .or_insert_with(|| TravelTimeData::new(self.num_bins))
+            .get_travel_time(link, time_slot, now, bin_size, getter);
 
         if let Some(vehicle) = vehicle {
             if vehicle.max_v.is_finite() && vehicle.max_v > 0.0 {
@@ -141,9 +132,9 @@ impl TravelTimeCalculator {
     }
 
     pub fn flush(&mut self) {
-        self.travel_time_bins_by_link = IntMap::default();
-        self.consolidated_travel_times_by_link = IntMap::default();
-        self.dirty_links = IntSet::default();
+        for data in self.travel_time_data_by_link.values_mut() {
+            data.flush();
+        }
     }
 
     fn clear_vehicle_state(&mut self, vehicle: &Id<InternalVehicle>) {
@@ -157,38 +148,77 @@ impl TravelTimeCalculator {
         let slot = usize::try_from(slot).unwrap_or(usize::MAX);
         slot.min(self.num_bins - 1)
     }
+}
 
-    fn consolidated_travel_times(&mut self, link: &Link) -> &[Duration] {
-        let needs_update = self.dirty_links.remove(&link.id)
-            || !self
-                .consolidated_travel_times_by_link
-                .contains_key(&link.id);
+impl TravelTimeData {
+    fn new(num_bins: usize) -> Self {
+        TravelTimeData {
+            travel_time_bins: vec![TravelTimeBin::default(); num_bins],
+            consolidated_travel_times: None,
+            dirty: true,
+        }
+    }
 
-        if needs_update {
-            let consolidated = self.build_consolidated_travel_times(link);
-            self.consolidated_travel_times_by_link
-                .insert(link.id.clone(), consolidated);
+    fn observe(&mut self, slot: usize, travel_time: Duration) {
+        let bin = &mut self.travel_time_bins[slot];
+        let next_count = bin.count + 1;
+        bin.mean_nanos = ((bin.mean_nanos * bin.count as f64) + duration_to_nanos_f64(travel_time))
+            / next_count as f64;
+        bin.count = next_count;
+        self.dirty = true;
+    }
+
+    fn get_travel_time(
+        &mut self,
+        link: &Link,
+        slot: usize,
+        now: SimTime,
+        bin_size: Duration,
+        getter: TravelTimeGetter,
+    ) -> Duration {
+        let travel_times = self.consolidated_travel_times(link, bin_size);
+        match getter {
+            TravelTimeGetter::Average => travel_times[slot],
+            TravelTimeGetter::LinearInterpolation => {
+                interpolated_travel_time(travel_times, now, bin_size)
+            }
+        }
+    }
+
+    fn flush(&mut self) {
+        self.travel_time_bins.fill(TravelTimeBin::default());
+        self.consolidated_travel_times = None;
+        self.dirty = true;
+    }
+
+    fn consolidated_travel_times(&mut self, link: &Link, bin_size: Duration) -> &[Duration] {
+        if self.dirty || self.consolidated_travel_times.is_none() {
+            self.consolidated_travel_times =
+                Some(self.build_consolidated_travel_times(link, bin_size));
+            self.dirty = false;
         }
 
-        self.consolidated_travel_times_by_link
-            .get(&link.id)
+        self.consolidated_travel_times
+            .as_deref()
             .expect("consolidated travel times must exist after update")
     }
 
-    fn build_consolidated_travel_times(&self, link: &Link) -> Vec<Duration> {
+    fn build_consolidated_travel_times(&self, link: &Link, bin_size: Duration) -> Vec<Duration> {
         let freespeed_travel_time = travel_time_from_speed(link.length, link.freespeed);
-        let mut result = vec![freespeed_travel_time; self.num_bins];
+        let mut result = vec![freespeed_travel_time; self.travel_time_bins.len()];
 
-        if let Some(bins) = self.travel_time_bins_by_link.get(&link.id) {
-            for (i, bin) in bins.iter().enumerate() {
-                if bin.count > 0 {
-                    result[i] = Duration::from_secs_f64(bin.mean_nanos / 1_000_000_000.0);
-                }
+        for (i, bin) in self.travel_time_bins.iter().enumerate() {
+            if bin.count > 0 {
+                result[i] = Duration::from_secs_f64(bin.mean_nanos / 1_000_000_000.0);
             }
         }
 
+        // MATSim does not let an empty bin immediately fall back to freespeed after a very slow
+        // observed bin. Instead, each following bin may drop by at most one bin size. For example,
+        // with 900s bins and a 3000s observation in bin 0, empty later bins become 2100s, 1200s,
+        // 300s, and only then freespeed again.
         for i in 1..result.len() {
-            let lower_bound = result[i - 1].saturating_sub(self.bin_size);
+            let lower_bound = result[i - 1].saturating_sub(bin_size);
             if result[i] < lower_bound {
                 result[i] = lower_bound;
             }
@@ -247,8 +277,7 @@ fn interpolated_travel_time(
 mod test {
     use crate::simulation::InternalAttributes;
     use crate::simulation::events::{
-        LinkEnterEvent, LinkLeaveEvent, PersonLeavesVehicleEvent, VehicleEntersTrafficEvent,
-        VehicleLeavesTrafficEvent,
+        LinkEnterEvent, LinkLeaveEvent, VehicleEntersTrafficEvent, VehicleLeavesTrafficEvent,
     };
     use crate::simulation::id::Id;
     use crate::simulation::replanning::routing::travel_time_collector::{
@@ -261,6 +290,8 @@ mod test {
     use macros::deterministic_id_test;
     use nohash_hasher::IntSet;
     use std::time::Duration;
+
+    use super::TravelTimeData;
 
     fn calculator(
         modes: IntSet<Id<String>>,
@@ -361,19 +392,6 @@ mod test {
         }
     }
 
-    fn person_leaves_vehicle_event(
-        time: SimTime,
-        person: &Id<InternalPerson>,
-        vehicle: &Id<InternalVehicle>,
-    ) -> PersonLeavesVehicleEvent {
-        PersonLeavesVehicleEvent {
-            time,
-            person: person.clone(),
-            vehicle: vehicle.clone(),
-            attributes: InternalAttributes::default(),
-        }
-    }
-
     fn average_travel_time(
         calculator: &mut TravelTimeCalculator,
         link: &Link,
@@ -409,23 +427,31 @@ mod test {
     fn records_travel_time_in_enter_time_slot() {
         let link = link("1", 100.0, 100.0);
         let vehicle = vehicle("v1", 20.0);
+
+        // 10 bin à 10s
         let mut calculator = calculator(IntSet::default(), 10, 100);
 
+        // in bin 1
         calculator.process_link_enter_event(&link_enter_event(
             SimTime::from_secs(9),
             &link.id,
             &vehicle.id,
         ));
+
+        // in bin 2
         calculator.process_link_leave_event(&link_leave_event(
             SimTime::from_secs(14),
             &link.id,
             &vehicle.id,
         ));
 
+        // observed travel time registered in bin 1
         assert_eq!(
             Duration::from_secs(5),
             average_travel_time(&mut calculator, &link, 0)
         );
+
+        // freespeed travel time registered in bin 2
         assert_eq!(
             Duration::from_secs(1),
             average_travel_time(&mut calculator, &link, 10)
@@ -439,6 +465,7 @@ mod test {
         let vehicle2 = vehicle("v2", 20.0);
         let mut calculator = calculator(IntSet::default(), 10, 100);
 
+        // Travel time 2
         calculator.process_link_enter_event(&link_enter_event(
             SimTime::from_secs(2),
             &link.id,
@@ -449,6 +476,8 @@ mod test {
             &link.id,
             &vehicle1.id,
         ));
+
+        // Travel time 4
         calculator.process_link_enter_event(&link_enter_event(
             SimTime::from_secs(3),
             &link.id,
@@ -460,6 +489,7 @@ mod test {
             &vehicle2.id,
         ));
 
+        // mean travel time is 3
         assert_eq!(
             Duration::from_secs(3),
             average_travel_time(&mut calculator, &link, 0)
@@ -518,6 +548,7 @@ mod test {
             &vehicle.id,
         ));
 
+        // returns freespeed travel time because the vehicle was ignored due to its network mode
         assert_eq!(
             Duration::from_secs(1),
             average_travel_time(&mut calculator, &link, 0)
@@ -541,6 +572,7 @@ mod test {
             &vehicle.id,
         ));
 
+        // returns the observed travel time
         assert_eq!(
             Duration::from_secs(5),
             average_travel_time(&mut calculator, &link, 10)
@@ -612,6 +644,10 @@ mod test {
             Duration::from_secs(300),
             average_travel_time(&mut calculator, &link, 2700)
         );
+        assert_eq!(
+            Duration::from_secs(1),
+            average_travel_time(&mut calculator, &link, 3600)
+        );
     }
 
     #[deterministic_id_test]
@@ -676,6 +712,153 @@ mod test {
                 &link,
                 SimTime::from_secs(0),
                 Some(&slow_vehicle),
+                TravelTimeGetter::Average,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn data_running_mean_per_slot() {
+        let link = link("1", 100.0, 100.0);
+        let mut data = TravelTimeData::new(3);
+
+        data.observe(0, Duration::from_secs(2));
+        data.observe(0, Duration::from_secs(4));
+
+        assert_eq!(
+            Duration::from_secs(3),
+            data.get_travel_time(
+                &link,
+                0,
+                SimTime::from_secs(0),
+                Duration::from_secs(10),
+                TravelTimeGetter::Average,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn data_empty_bins_use_freespeed() {
+        let link = link("1", 100.0, 10.0);
+        let mut data = TravelTimeData::new(3);
+
+        assert_eq!(
+            Duration::from_secs(10),
+            data.get_travel_time(
+                &link,
+                1,
+                SimTime::from_secs(10),
+                Duration::from_secs(10),
+                TravelTimeGetter::Average,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn data_consolidation_cascades_previous_bin_minus_bin_size() {
+        let link = link("1", 100.0, 100.0);
+        let mut data = TravelTimeData::new(4);
+        let bin_size = Duration::from_secs(900);
+
+        data.observe(0, Duration::from_secs(3000));
+
+        assert_eq!(
+            Duration::from_secs(2100),
+            data.get_travel_time(
+                &link,
+                1,
+                SimTime::from_secs(900),
+                bin_size,
+                TravelTimeGetter::Average,
+            )
+        );
+        assert_eq!(
+            Duration::from_secs(1200),
+            data.get_travel_time(
+                &link,
+                2,
+                SimTime::from_secs(1800),
+                bin_size,
+                TravelTimeGetter::Average,
+            )
+        );
+        assert_eq!(
+            Duration::from_secs(300),
+            data.get_travel_time(
+                &link,
+                3,
+                SimTime::from_secs(2700),
+                bin_size,
+                TravelTimeGetter::Average,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn data_linear_interpolation_uses_neighboring_bin_midpoints() {
+        let link = link("1", 100.0, 100.0);
+        let mut data = TravelTimeData::new(3);
+
+        data.observe(0, Duration::from_secs(10));
+        data.observe(1, Duration::from_secs(20));
+
+        assert_eq!(
+            Duration::from_secs(15),
+            data.get_travel_time(
+                &link,
+                1,
+                SimTime::from_secs(10),
+                Duration::from_secs(10),
+                TravelTimeGetter::LinearInterpolation,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn data_reconsolidates_after_new_observation() {
+        let link = link("1", 100.0, 100.0);
+        let mut data = TravelTimeData::new(3);
+
+        data.observe(0, Duration::from_secs(10));
+        assert_eq!(
+            Duration::from_secs(10),
+            data.get_travel_time(
+                &link,
+                0,
+                SimTime::from_secs(0),
+                Duration::from_secs(10),
+                TravelTimeGetter::Average,
+            )
+        );
+
+        data.observe(0, Duration::from_secs(20));
+        assert_eq!(
+            Duration::from_secs(15),
+            data.get_travel_time(
+                &link,
+                0,
+                SimTime::from_secs(0),
+                Duration::from_secs(10),
+                TravelTimeGetter::Average,
+            )
+        );
+    }
+
+    #[deterministic_id_test]
+    fn data_flush_clears_observations() {
+        let link = link("1", 100.0, 100.0);
+        let mut data = TravelTimeData::new(3);
+
+        data.observe(0, Duration::from_secs(10));
+        data.flush();
+
+        assert_eq!(
+            Duration::from_secs(1),
+            data.get_travel_time(
+                &link,
+                0,
+                SimTime::from_secs(0),
+                Duration::from_secs(10),
                 TravelTimeGetter::Average,
             )
         );

--- a/rust_qsim/src/simulation/scenario/mod.rs
+++ b/rust_qsim/src/simulation/scenario/mod.rs
@@ -41,14 +41,12 @@ impl Coordinate {
         Coordinate::new_3d((a.x + b.x) / 2., (a.y + b.y) / 2., (a.z + b.z) / 2.)
     }
 
-    /// Returns the orthogonal projection of `point` onto the infinite line
+    /// Returns the orthogonal projection of `point` onto the line segment
     /// defined by `line_from` and `line_to`.
     ///
-    /// The returned coordinate is the closest point on that line to `point`.
-    /// Note that the projection is not clamped to the segment between
-    /// `line_from` and `line_to`, so the result may lie outside that segment.
+    /// The returned coordinate is the closest point on that segment to `point`.
     pub fn orthogonal_projection(point: &Self, line_from: &Self, line_to: &Self) -> Self {
-        // Orthogonal projection of point onto the line through from and to:
+        // Orthogonal projection of point onto the segment from and to:
         // v = from - to
         // t = dot(point - from, v) / dot(v, v)
         // projection = from + t * v
@@ -56,11 +54,18 @@ impl Coordinate {
         let dx = line_to.x - line_from.x;
         let dy = line_to.y - line_from.y;
         let dz = line_to.z - line_from.z;
+        let segment_length_squared = dx * dx + dy * dy + dz * dz;
 
-        let t = ((point.x - line_from.x) * dx
+        // line has 0 length
+        if segment_length_squared == 0.0 {
+            return line_from.clone();
+        }
+
+        let t = (((point.x - line_from.x) * dx
             + (point.y - line_from.y) * dy
             + (point.z - line_from.z) * dz)
-            / (dx * dx + dy * dy + dz * dz);
+            / segment_length_squared)
+            .clamp(0.0, 1.0);
 
         Coordinate::new_3d(
             line_from.x + t * dx,
@@ -73,6 +78,74 @@ impl Coordinate {
 impl Default for Coordinate {
     fn default() -> Self {
         Self::new_3d(0.0, 0.0, 0.0)
+    }
+}
+
+#[cfg(test)]
+mod coordinate_tests {
+    use super::Coordinate;
+    use assert_approx_eq::assert_approx_eq;
+
+    fn assert_coordinate_eq(expected: Coordinate, actual: Coordinate) {
+        assert_approx_eq!(expected.x, actual.x);
+        assert_approx_eq!(expected.y, actual.y);
+        assert_approx_eq!(expected.z, actual.z);
+    }
+
+    #[test]
+    fn orthogonal_projection_inside_segment_keeps_projection() {
+        let projection = Coordinate::orthogonal_projection(
+            &Coordinate::new_2d(5.0, 4.0),
+            &Coordinate::new_2d(0.0, 0.0),
+            &Coordinate::new_2d(10.0, 0.0),
+        );
+
+        assert_coordinate_eq(Coordinate::new_2d(5.0, 0.0), projection);
+    }
+
+    #[test]
+    fn orthogonal_projection_before_segment_clamps_to_from() {
+        let projection = Coordinate::orthogonal_projection(
+            &Coordinate::new_2d(-5.0, 4.0),
+            &Coordinate::new_2d(0.0, 0.0),
+            &Coordinate::new_2d(10.0, 0.0),
+        );
+
+        assert_coordinate_eq(Coordinate::new_2d(0.0, 0.0), projection);
+    }
+
+    #[test]
+    fn orthogonal_projection_after_segment_clamps_to_to() {
+        let projection = Coordinate::orthogonal_projection(
+            &Coordinate::new_2d(15.0, 4.0),
+            &Coordinate::new_2d(0.0, 0.0),
+            &Coordinate::new_2d(10.0, 0.0),
+        );
+
+        assert_coordinate_eq(Coordinate::new_2d(10.0, 0.0), projection);
+    }
+
+    #[test]
+    fn orthogonal_projection_clamps_on_3d_segment() {
+        let projection = Coordinate::orthogonal_projection(
+            &Coordinate::new_3d(7.0, 7.0, 7.0),
+            &Coordinate::new_3d(0.0, 0.0, 0.0),
+            &Coordinate::new_3d(2.0, 2.0, 2.0),
+        );
+
+        assert_coordinate_eq(Coordinate::new_3d(2.0, 2.0, 2.0), projection);
+    }
+
+    #[test]
+    fn orthogonal_projection_zero_length_segment_returns_endpoint() {
+        let endpoint = Coordinate::new_3d(1.0, 2.0, 3.0);
+        let projection = Coordinate::orthogonal_projection(
+            &Coordinate::new_3d(7.0, 7.0, 7.0),
+            &endpoint,
+            &endpoint,
+        );
+
+        assert_coordinate_eq(endpoint, projection);
     }
 }
 

--- a/rust_qsim/src/simulation/scenario/mod.rs
+++ b/rust_qsim/src/simulation/scenario/mod.rs
@@ -6,6 +6,7 @@ pub mod trip_structure_utils;
 pub mod vehicles;
 
 use crate::simulation::config::Config;
+use crate::simulation::network::LinkStorageCapacities;
 use crate::simulation::network::sim_network::SimNetworkPartition;
 use crate::simulation::{id, io};
 use network::Network;
@@ -261,14 +262,19 @@ impl From<Scenario> for ControllerScenario {
 }
 
 impl ControllerScenario {
-    pub fn split_for_mobsim(&mut self) -> Vec<MobsimInput> {
+    pub(crate) fn split_for_mobsim(
+        &mut self,
+        storage_capacities: &LinkStorageCapacities,
+    ) -> Vec<MobsimInput> {
         let num_parts = self.core.config.partitioning().num_parts;
         let population = std::mem::take(&mut self.population);
         population
             .split_by_start_link_partition(&self.core.network, num_parts)
             .into_iter()
             .enumerate()
-            .map(|(rank, population)| self.create_mobsim_input(rank as u32, population))
+            .map(|(rank, population)| {
+                self.create_mobsim_input(rank as u32, population, storage_capacities)
+            })
             .collect()
     }
 
@@ -293,8 +299,14 @@ impl ControllerScenario {
         self.population = population;
     }
 
-    fn create_mobsim_input(&self, rank: u32, population: Population) -> MobsimInput {
-        let network_partition = Self::create_network_partition(&self.core, rank);
+    fn create_mobsim_input(
+        &self,
+        rank: u32,
+        population: Population,
+        storage_capacities: &LinkStorageCapacities,
+    ) -> MobsimInput {
+        let network_partition =
+            Self::create_network_partition(&self.core, storage_capacities, rank);
 
         info!(
             "Partition #{rank} network has: {} nodes and {} links. Population has {} agents",
@@ -314,9 +326,19 @@ impl ControllerScenario {
         }
     }
 
-    fn create_network_partition(core: &ScenarioCore, rank: u32) -> SimNetworkPartition {
+    fn create_network_partition(
+        core: &ScenarioCore,
+        storage_capacities: &LinkStorageCapacities,
+        rank: u32,
+    ) -> SimNetworkPartition {
         let base_seed = core.config.computational_setup().random_seed;
-        SimNetworkPartition::from_network(&core.network, rank, core.config.qsim(), base_seed)
+        SimNetworkPartition::from_network(
+            &core.network,
+            storage_capacities,
+            rank,
+            core.config.qsim(),
+            base_seed,
+        )
     }
 }
 
@@ -324,6 +346,7 @@ impl ControllerScenario {
 mod tests {
     use super::{ControllerScenario, Scenario};
     use crate::simulation::config::{Config, PartitionMethod};
+    use crate::simulation::network::LinkStorageCapacities;
     use crate::simulation::scenario::network::Network;
     use crate::simulation::scenario::population::Population;
     use crate::simulation::scenario::vehicles::Garage;
@@ -343,6 +366,7 @@ mod tests {
             &PartitionMethod::None,
         );
 
+        let storage_capacities = LinkStorageCapacities::from_network(&network, config.qsim());
         let mut scenario: ControllerScenario = Scenario {
             network,
             garage,
@@ -351,7 +375,7 @@ mod tests {
         }
         .into();
 
-        let inputs = scenario.split_for_mobsim();
+        let inputs = scenario.split_for_mobsim(&storage_capacities);
 
         assert!(scenario.population.persons.is_empty());
 

--- a/rust_qsim/src/simulation/scenario/mod.rs
+++ b/rust_qsim/src/simulation/scenario/mod.rs
@@ -331,14 +331,7 @@ impl ControllerScenario {
         storage_capacities: &LinkStorageCapacities,
         rank: u32,
     ) -> SimNetworkPartition {
-        let base_seed = core.config.computational_setup().random_seed;
-        SimNetworkPartition::from_network(
-            &core.network,
-            storage_capacities,
-            rank,
-            core.config.qsim(),
-            base_seed,
-        )
+        SimNetworkPartition::from_network(&core.network, storage_capacities, rank, &core.config)
     }
 }
 

--- a/rust_qsim/src/simulation/scenario/network.rs
+++ b/rust_qsim/src/simulation/scenario/network.rs
@@ -1,10 +1,14 @@
 use crate::simulation::InternalAttributes;
 use crate::simulation::config::PartitionMethod;
 use crate::simulation::id::Id;
-use crate::simulation::io::proto::proto_network::{load_from_proto, write_to_proto};
+use crate::simulation::io::proto::proto_network::{
+    load_from_proto, write_to_proto_with_link_attribute_overrides,
+};
 use crate::simulation::io::xml::attributes::IOAttributes;
 use crate::simulation::io::xml::network;
-use crate::simulation::io::xml::network::{IOLink, IONetwork, IONode, write_to_xml};
+use crate::simulation::io::xml::network::{
+    IOLink, IONetwork, IONode, write_to_xml_with_link_attribute_overrides,
+};
 use crate::simulation::network::metis_partitioning;
 use crate::simulation::scenario::Coordinate;
 use itertools::Itertools;
@@ -45,6 +49,8 @@ pub struct Link {
     pub attributes: InternalAttributes,
 }
 
+pub(crate) type LinkAttributeOverrides = IntMap<Id<Link>, InternalAttributes>;
+
 impl Default for Network {
     fn default() -> Self {
         Network::new()
@@ -84,6 +90,14 @@ impl Network {
 
     pub fn to_file(&self, file_path: &Path) {
         to_file(self, file_path);
+    }
+
+    pub(crate) fn to_file_with_link_attribute_overrides(
+        &self,
+        file_path: &Path,
+        overrides: &LinkAttributeOverrides,
+    ) {
+        to_file_with_link_attribute_overrides(self, file_path, overrides);
     }
 
     pub fn add_node(&mut self, node: Node) {
@@ -285,7 +299,7 @@ impl From<crate::generated::network::Network> for Network {
             let modes: IntSet<Id<String>> =
                 wl.modes.iter().map(|id| Id::get_from_ext(id)).collect();
 
-            let link = Link::new(
+            let mut link = Link::new(
                 Id::get_from_ext(&wl.id),
                 Id::get_from_ext(&wl.from),
                 Id::get_from_ext(&wl.to),
@@ -296,6 +310,7 @@ impl From<crate::generated::network::Network> for Network {
                 modes,
                 wl.partition,
             );
+            link.attributes = InternalAttributes::from(&wl.attributes);
             result.add_link(link);
         }
         info!("Finished converting protobuf wire type into Network");
@@ -334,7 +349,7 @@ fn add_io_link(network: &mut Network, io_link: &IOLink) {
     let from_id = Id::get_from_ext(&io_link.from);
     let to_id = Id::get_from_ext(&io_link.to);
 
-    let link = Link::new(
+    let mut link = Link::new(
         id,
         from_id,
         to_id,
@@ -345,6 +360,17 @@ fn add_io_link(network: &mut Network, io_link: &IOLink) {
         modes,
         partition,
     );
+    link.attributes = io_link
+        .attributes
+        .clone()
+        .map(|mut attributes| {
+            // partition is stored in a field, thus can be omitted when reading the attributes.
+            attributes
+                .attributes
+                .retain(|attribute| attribute.name != "partition");
+            InternalAttributes::from(attributes)
+        })
+        .unwrap_or_default();
     network.add_link(link);
 }
 
@@ -430,18 +456,39 @@ pub fn from_file(path: &Path) -> Network {
 }
 
 pub fn to_file(network: &Network, path: &Path) {
+    to_file_with_link_attribute_overrides(network, path, &LinkAttributeOverrides::default());
+}
+
+pub(crate) fn to_file_with_link_attribute_overrides(
+    network: &Network,
+    path: &Path,
+    overrides: &LinkAttributeOverrides,
+) {
     if path.extension().unwrap().eq("binpb") {
-        write_to_proto(network, path);
+        write_to_proto_with_link_attribute_overrides(network, path, overrides);
     } else if path.extension().unwrap().eq("xml")
         || path.extension().unwrap().eq("gz")
         || path.extension().unwrap().eq("zst")
     {
-        write_to_xml(network, path);
+        write_to_xml_with_link_attribute_overrides(network, path, overrides);
     } else {
         panic!(
             "Tried to write {path:?} . File format not supported. Either use `.xml`, `.xml.gz`, `.xml.zst`, or `.binpb` as extension"
         );
     }
+}
+
+pub(crate) fn merged_link_attributes(
+    link: &Link,
+    overrides: &LinkAttributeOverrides,
+) -> InternalAttributes {
+    let mut attributes = link.attributes.clone();
+    if let Some(link_overrides) = overrides.get(&link.id) {
+        for (key, value) in link_overrides.iter() {
+            attributes.insert(key.clone(), value);
+        }
+    }
+    attributes
 }
 
 pub mod utils {

--- a/rust_qsim/src/simulation/scenario/population.rs
+++ b/rust_qsim/src/simulation/scenario/population.rs
@@ -484,8 +484,8 @@ impl InternalRoute {
                 let route = io
                     .route
                     .unwrap_or_default()
-                    .split(' ')
-                    .map(|link| Id::create(link.trim()))
+                    .split_whitespace()
+                    .map(Id::create)
                     .collect();
                 InternalRoute::Network(InternalNetworkRoute {
                     generic_delegate: generic,
@@ -1006,6 +1006,33 @@ mod tests {
         });
 
         assert_eq!("person", person.subpopulation().external());
+    }
+
+    #[deterministic_id_test]
+    fn network_route_ignores_xml_text_whitespace() {
+        let route = InternalRoute::from_io(
+            IORoute {
+                r#type: Some("links".to_string()),
+                start_link: Some("1".to_string()),
+                end_link: Some("20".to_string()),
+                trav_time: None,
+                distance: None,
+                vehicle: Some("1_car".to_string()),
+                route: Some("1 6 15 20\n                ".to_string()),
+            },
+            Id::create("1"),
+            Id::create("car"),
+        );
+
+        assert_eq!(
+            vec![
+                Id::<Link>::get_from_ext("1"),
+                Id::<Link>::get_from_ext("6"),
+                Id::<Link>::get_from_ext("15"),
+                Id::<Link>::get_from_ext("20"),
+            ],
+            route.as_network().unwrap().route
+        );
     }
 
     #[deterministic_id_test]

--- a/rust_qsim/src/simulation/scenario/population.rs
+++ b/rust_qsim/src/simulation/scenario/population.rs
@@ -961,7 +961,7 @@ mod tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    #[test]
+    #[deterministic_id_test]
     fn cmp_end_time_uses_bounded_open_ended_sentinel() {
         let activity = InternalActivity::new(
             Some(Coordinate::new_2d(0.0, 0.0)),
@@ -978,7 +978,7 @@ mod tests {
         );
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn person_from_xml_uses_subpopulation_attribute() {
         let person = InternalPerson::from(IOPerson {
             attributes: Some(IOAttributes {
@@ -999,7 +999,7 @@ mod tests {
         assert_eq!("freight", person.subpopulation().external());
     }
 
-    #[test]
+    #[deterministic_id_test]
     fn person_from_xml_defaults_subpopulation_to_person() {
         let person = InternalPerson::from(IOPerson {
             attributes: None,

--- a/rust_qsim/src/test_utils.rs
+++ b/rust_qsim/src/test_utils.rs
@@ -79,7 +79,7 @@ pub fn create_vehicle_type(
     }
 }
 
-pub fn config() -> config::QSim {
+pub fn qsim_config() -> config::QSim {
     config::QSim {
         start_time: 0,
         end_time: 0,
@@ -88,4 +88,10 @@ pub fn config() -> config::QSim {
         stuck_threshold: u32::MAX,
         main_modes: vec![String::from("car")],
     }
+}
+
+pub fn config() -> config::Config {
+    let mut config = config::Config::default();
+    config.set_qsim(qsim_config());
+    config
 }

--- a/rust_qsim/tests/resources/equil/equil-config-1.yml
+++ b/rust_qsim/tests/resources/equil/equil-config-1.yml
@@ -18,11 +18,14 @@ modules:
     type: Output
     overwrite_files: DeleteDirectoryIfExists
     output_dir: ./test_output/simulation/equil_single_part
-    write_events: XmlGz
+    write_events: File
   routing:
     type: Routing
     mode: UsePlans
-  simulation:
-    type: Simulation
+  controller:
+    type: Controller
     last_iteration: 0
+    compression_type: Zst
+  qsim:
+    type: QSim
     main_modes: [ "car" ]

--- a/rust_qsim/tests/resources/equil/equil-config-2.yml
+++ b/rust_qsim/tests/resources/equil/equil-config-2.yml
@@ -18,11 +18,14 @@ modules:
     type: Output
     overwrite_files: DeleteDirectoryIfExists
     output_dir: ./test_output/simulation/equil_with_channels
-    write_events: XmlGz
+    write_events: File
   routing:
     type: Routing
     mode: UsePlans
-  simulation:
-    type: Simulation
+  controller:
+    type: Controller
     last_iteration: 0
+    compression_type: Zst
+  qsim:
+    type: QSim
     main_modes: [ "car" ]

--- a/rust_qsim/tests/resources/equil/expected_events.xml
+++ b/rust_qsim/tests/resources/equil/expected_events.xml
@@ -1,71 +1,71 @@
 <?xml version="1.0" encoding="utf-8"?>
 <events version="1.0">
-<event time="21600" type="actend" person="1" link="1" x="-25000" y="0" actType="h"/>
-<event time="21600" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
-<event time="21600" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="21600" type="arrival" person="1" link="1" legMode="walk"/>
-<event time="21601" type="actstart" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="21601" type="actend" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="21601" type="departure" person="1" link="1" legMode="car" computationalRoutingMode="car"/>
-<event time="21601" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="21601" type="vehicle enters traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="21602" type="left link" link="1" vehicle="1_car"/>
-<event time="21602" type="entered link" link="2" vehicle="1_car"/>
-<event time="21962" type="left link" link="2" vehicle="1_car"/>
-<event time="21962" type="entered link" link="11" vehicle="1_car"/>
-<event time="22142" type="left link" link="11" vehicle="1_car"/>
-<event time="22142" type="entered link" link="20" vehicle="1_car"/>
-<event time="22501" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="22501" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="22501" type="arrival" person="1" link="20" legMode="car"/>
-<event time="22502" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="22502" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="22502" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="29120" type="travelled" person="1" distance="5514.6" mode="walk"/>
-<event time="29120" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="29121" type="actstart" person="1" link="20" x="3456" y="4242" actType="w"/>
-<event time="29721" type="actend" person="1" link="20" x="3456" y="4242" actType="w"/>
-<event time="29721" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="36339" type="travelled" person="1" distance="5514.6" mode="walk"/>
-<event time="36339" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="36340" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="36340" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="36340" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
-<event time="36340" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="36340" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="36340" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="36340" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="36340" type="arrival" person="1" link="20" legMode="car"/>
-<event time="36341" type="actstart" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="36341" type="actend" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="36341" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="36341" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="36341" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="36342" type="actstart" person="1" link="20" x="10000" y="0" actType="w"/>
-<event time="48942" type="actend" person="1" link="20" x="10000" y="0" actType="w"/>
-<event time="48942" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="48942" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="48942" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="48943" type="actstart" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="48943" type="actend" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="48943" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
-<event time="48943" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="48943" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="48944" type="left link" link="20" vehicle="1_car"/>
-<event time="48944" type="entered link" link="21" vehicle="1_car"/>
-<event time="49304" type="left link" link="21" vehicle="1_car"/>
-<event time="49304" type="entered link" link="22" vehicle="1_car"/>
-<event time="50564" type="left link" link="22" vehicle="1_car"/>
-<event time="50564" type="entered link" link="23" vehicle="1_car"/>
-<event time="50924" type="left link" link="23" vehicle="1_car"/>
-<event time="50924" type="entered link" link="1" vehicle="1_car"/>
-<event time="51283" type="vehicle leaves traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="51283" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="51283" type="arrival" person="1" link="1" legMode="car"/>
-<event time="51284" type="actstart" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="51284" type="actend" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="51284" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
-<event time="51284" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="51284" type="arrival" person="1" link="1" legMode="walk"/>
-<event time="51285" type="actstart" person="1" link="1" x="-25000" y="0" actType="h"/>
+    <event time="21600" type="actend" person="1" link="1" x="-25000" y="0" actType="h"/>
+    <event time="21600" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
+    <event time="29400" type="travelled" person="1" distance="6500" mode="walk"/>
+    <event time="29400" type="arrival" person="1" link="1" legMode="walk"/>
+    <event time="29401" type="actstart" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+    <event time="29401" type="actend" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+    <event time="29401" type="departure" person="1" link="1" legMode="car" computationalRoutingMode="car"/>
+    <event time="29401" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+    <event time="29401" type="vehicle enters traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
+    <event time="29402" type="left link" link="1" vehicle="1_car"/>
+    <event time="29402" type="entered link" link="2" vehicle="1_car"/>
+    <event time="29762" type="left link" link="2" vehicle="1_car"/>
+    <event time="29762" type="entered link" link="11" vehicle="1_car"/>
+    <event time="29942" type="left link" link="11" vehicle="1_car"/>
+    <event time="29942" type="entered link" link="20" vehicle="1_car"/>
+    <event time="30301" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+    <event time="30301" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+    <event time="30301" type="arrival" person="1" link="20" legMode="car"/>
+    <event time="30302" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+    <event time="30302" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+    <event time="30302" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+    <event time="36920" type="travelled" person="1" distance="5514.6" mode="walk"/>
+    <event time="36920" type="arrival" person="1" link="20" legMode="walk"/>
+    <event time="36921" type="actstart" person="1" link="20" x="3456" y="4242" actType="w"/>
+    <event time="37521" type="actend" person="1" link="20" x="3456" y="4242" actType="w"/>
+    <event time="37521" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+    <event time="44139" type="travelled" person="1" distance="5514.6" mode="walk"/>
+    <event time="44139" type="arrival" person="1" link="20" legMode="walk"/>
+    <event time="44140" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+    <event time="44140" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+    <event time="44140" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
+    <event time="44140" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+    <event time="44140" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+    <event time="44140" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+    <event time="44140" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+    <event time="44140" type="arrival" person="1" link="20" legMode="car"/>
+    <event time="44141" type="actstart" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+    <event time="44141" type="actend" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+    <event time="44141" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+    <event time="51941" type="travelled" person="1" distance="6500" mode="walk"/>
+    <event time="51941" type="arrival" person="1" link="20" legMode="walk"/>
+    <event time="51942" type="actstart" person="1" link="20" x="10000" y="0" actType="w"/>
+    <event time="64542" type="actend" person="1" link="20" x="10000" y="0" actType="w"/>
+    <event time="64542" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+    <event time="72342" type="travelled" person="1" distance="6500" mode="walk"/>
+    <event time="72342" type="arrival" person="1" link="20" legMode="walk"/>
+    <event time="72343" type="actstart" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+    <event time="72343" type="actend" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+    <event time="72343" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
+    <event time="72343" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+    <event time="72343" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+    <event time="72344" type="left link" link="20" vehicle="1_car"/>
+    <event time="72344" type="entered link" link="21" vehicle="1_car"/>
+    <event time="72704" type="left link" link="21" vehicle="1_car"/>
+    <event time="72704" type="entered link" link="22" vehicle="1_car"/>
+    <event time="73964" type="left link" link="22" vehicle="1_car"/>
+    <event time="73964" type="entered link" link="23" vehicle="1_car"/>
+    <event time="74324" type="left link" link="23" vehicle="1_car"/>
+    <event time="74324" type="entered link" link="1" vehicle="1_car"/>
+    <event time="74683" type="vehicle leaves traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
+    <event time="74683" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+    <event time="74683" type="arrival" person="1" link="1" legMode="car"/>
+    <event time="74684" type="actstart" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+    <event time="74684" type="actend" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+    <event time="74684" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
+    <event time="82484" type="travelled" person="1" distance="6500" mode="walk"/>
+    <event time="82484" type="arrival" person="1" link="1" legMode="walk"/>
+    <event time="82485" type="actstart" person="1" link="1" x="-25000" y="0" actType="h"/>
 </events>

--- a/rust_qsim/tests/resources/equil/expected_events_10_ticks.xml
+++ b/rust_qsim/tests/resources/equil/expected_events_10_ticks.xml
@@ -2,70 +2,70 @@
 <events version="1.0">
 <event time="21600" type="actend" person="1" link="1" x="-25000" y="0" actType="h"/>
 <event time="21600" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
-<event time="21600" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="21600" type="arrival" person="1" link="1" legMode="walk"/>
-<event time="21600.1" type="actstart" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="21600.1" type="actend" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="21600.1" type="departure" person="1" link="1" legMode="car" computationalRoutingMode="car"/>
-<event time="21600.1" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="21600.1" type="vehicle enters traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="21600.2" type="left link" link="1" vehicle="1_car"/>
-<event time="21600.2" type="entered link" link="2" vehicle="1_car"/>
-<event time="21960.2" type="left link" link="2" vehicle="1_car"/>
-<event time="21960.2" type="entered link" link="11" vehicle="1_car"/>
-<event time="22140.2" type="left link" link="11" vehicle="1_car"/>
-<event time="22140.2" type="entered link" link="20" vehicle="1_car"/>
-<event time="22500.1" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="22500.1" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="22500.1" type="arrival" person="1" link="20" legMode="car"/>
-<event time="22500.2" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="22500.2" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="22500.2" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="29117.8" type="travelled" person="1" distance="5514.6" mode="walk"/>
-<event time="29117.8" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="29117.9" type="actstart" person="1" link="20" x="3456" y="4242" actType="w"/>
-<event time="29717.9" type="actend" person="1" link="20" x="3456" y="4242" actType="w"/>
-<event time="29717.9" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="36335.5" type="travelled" person="1" distance="5514.6" mode="walk"/>
-<event time="36335.5" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="36335.6" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="36335.6" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="36335.6" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
-<event time="36335.6" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="36335.6" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="36335.6" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="36335.6" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="36335.6" type="arrival" person="1" link="20" legMode="car"/>
-<event time="36335.7" type="actstart" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="36335.7" type="actend" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="36335.7" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="36335.7" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="36335.7" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="36335.8" type="actstart" person="1" link="20" x="10000" y="0" actType="w"/>
-<event time="48935.8" type="actend" person="1" link="20" x="10000" y="0" actType="w"/>
-<event time="48935.8" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="48935.8" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="48935.8" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="48935.9" type="actstart" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="48935.9" type="actend" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="48935.9" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
-<event time="48935.9" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="48935.9" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="48936" type="left link" link="20" vehicle="1_car"/>
-<event time="48936" type="entered link" link="21" vehicle="1_car"/>
-<event time="49296" type="left link" link="21" vehicle="1_car"/>
-<event time="49296" type="entered link" link="22" vehicle="1_car"/>
-<event time="50555.9" type="left link" link="22" vehicle="1_car"/>
-<event time="50555.9" type="entered link" link="23" vehicle="1_car"/>
-<event time="50915.9" type="left link" link="23" vehicle="1_car"/>
-<event time="50915.9" type="entered link" link="1" vehicle="1_car"/>
-<event time="51275.8" type="vehicle leaves traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="51275.8" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="51275.8" type="arrival" person="1" link="1" legMode="car"/>
-<event time="51275.9" type="actstart" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="51275.9" type="actend" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="51275.9" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
-<event time="51275.9" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="51275.9" type="arrival" person="1" link="1" legMode="walk"/>
-<event time="51276" type="actstart" person="1" link="1" x="-25000" y="0" actType="h"/>
+<event time="29400" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="29400" type="arrival" person="1" link="1" legMode="walk"/>
+<event time="29400.1" type="actstart" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="29400.1" type="actend" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="29400.1" type="departure" person="1" link="1" legMode="car" computationalRoutingMode="car"/>
+<event time="29400.1" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+<event time="29400.1" type="vehicle enters traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="29400.2" type="left link" link="1" vehicle="1_car"/>
+<event time="29400.2" type="entered link" link="2" vehicle="1_car"/>
+<event time="29760.2" type="left link" link="2" vehicle="1_car"/>
+<event time="29760.2" type="entered link" link="11" vehicle="1_car"/>
+<event time="29940.2" type="left link" link="11" vehicle="1_car"/>
+<event time="29940.2" type="entered link" link="20" vehicle="1_car"/>
+<event time="30300.1" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="30300.1" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+<event time="30300.1" type="arrival" person="1" link="20" legMode="car"/>
+<event time="30300.2" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="30300.2" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="30300.2" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="36917.8" type="travelled" person="1" distance="5514.6" mode="walk"/>
+<event time="36917.8" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="36917.9" type="actstart" person="1" link="20" x="3456" y="4242" actType="w"/>
+<event time="37517.9" type="actend" person="1" link="20" x="3456" y="4242" actType="w"/>
+<event time="37517.9" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="44135.5" type="travelled" person="1" distance="5514.6" mode="walk"/>
+<event time="44135.5" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="44135.6" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="44135.6" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="44135.6" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
+<event time="44135.6" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+<event time="44135.6" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="44135.6" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="44135.6" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+<event time="44135.6" type="arrival" person="1" link="20" legMode="car"/>
+<event time="44135.7" type="actstart" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="44135.7" type="actend" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="44135.7" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="51935.7" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="51935.7" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="51935.8" type="actstart" person="1" link="20" x="10000" y="0" actType="w"/>
+<event time="64535.8" type="actend" person="1" link="20" x="10000" y="0" actType="w"/>
+<event time="64535.8" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="72335.8" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="72335.8" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="72335.9" type="actstart" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="72335.9" type="actend" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="72335.9" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
+<event time="72335.9" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+<event time="72335.9" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="72336" type="left link" link="20" vehicle="1_car"/>
+<event time="72336" type="entered link" link="21" vehicle="1_car"/>
+<event time="72696" type="left link" link="21" vehicle="1_car"/>
+<event time="72696" type="entered link" link="22" vehicle="1_car"/>
+<event time="73955.9" type="left link" link="22" vehicle="1_car"/>
+<event time="73955.9" type="entered link" link="23" vehicle="1_car"/>
+<event time="74315.9" type="left link" link="23" vehicle="1_car"/>
+<event time="74315.9" type="entered link" link="1" vehicle="1_car"/>
+<event time="74675.8" type="vehicle leaves traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="74675.8" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+<event time="74675.8" type="arrival" person="1" link="1" legMode="car"/>
+<event time="74675.9" type="actstart" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="74675.9" type="actend" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="74675.9" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
+<event time="82475.9" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="82475.9" type="arrival" person="1" link="1" legMode="walk"/>
+<event time="82476" type="actstart" person="1" link="1" x="-25000" y="0" actType="h"/>
 </events>

--- a/rust_qsim/tests/resources/equil/expected_events_simulate_network_route.xml
+++ b/rust_qsim/tests/resources/equil/expected_events_simulate_network_route.xml
@@ -2,70 +2,70 @@
 <events version="1.0">
 <event time="21600" type="actend" person="1" link="1" x="-25000" y="0" actType="h"/>
 <event time="21600" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
-<event time="21600" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="21600" type="arrival" person="1" link="1" legMode="walk"/>
-<event time="21601" type="actstart" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="21601" type="actend" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="21601" type="departure" person="1" link="1" legMode="car" computationalRoutingMode="car"/>
-<event time="21601" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="21601" type="vehicle enters traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="21602" type="left link" link="1" vehicle="1_car"/>
-<event time="21602" type="entered link" link="2" vehicle="1_car"/>
-<event time="21962" type="left link" link="2" vehicle="1_car"/>
-<event time="21962" type="entered link" link="11" vehicle="1_car"/>
-<event time="22142" type="left link" link="11" vehicle="1_car"/>
-<event time="22142" type="entered link" link="20" vehicle="1_car"/>
-<event time="22501" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="22501" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="22501" type="arrival" person="1" link="20" legMode="car"/>
-<event time="22502" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="22502" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="22502" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="29120" type="travelled" person="1" distance="5514.6" mode="walk"/>
-<event time="29120" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="29121" type="actstart" person="1" link="20" x="3456" y="4242" actType="w"/>
-<event time="29721" type="actend" person="1" link="20" x="3456" y="4242" actType="w"/>
-<event time="29721" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="36339" type="travelled" person="1" distance="5514.6" mode="walk"/>
-<event time="36339" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="36340" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="36340" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
-<event time="36340" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
-<event time="36340" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="36340" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="36340" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="36340" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="36340" type="arrival" person="1" link="20" legMode="car"/>
-<event time="36341" type="actstart" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="36341" type="actend" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="36341" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="36341" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="36341" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="36342" type="actstart" person="1" link="20" x="10000" y="0" actType="w"/>
-<event time="48942" type="actend" person="1" link="20" x="10000" y="0" actType="w"/>
-<event time="48942" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
-<event time="48942" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="48942" type="arrival" person="1" link="20" legMode="walk"/>
-<event time="48943" type="actstart" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="48943" type="actend" person="1" link="20" x="10000" y="0" actType="car interaction"/>
-<event time="48943" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
-<event time="48943" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
-<event time="48943" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="48944" type="left link" link="20" vehicle="1_car"/>
-<event time="48944" type="entered link" link="21" vehicle="1_car"/>
-<event time="49304" type="left link" link="21" vehicle="1_car"/>
-<event time="49304" type="entered link" link="22" vehicle="1_car"/>
-<event time="50564" type="left link" link="22" vehicle="1_car"/>
-<event time="50564" type="entered link" link="23" vehicle="1_car"/>
-<event time="50924" type="left link" link="23" vehicle="1_car"/>
-<event time="50924" type="entered link" link="1" vehicle="1_car"/>
-<event time="51283" type="vehicle leaves traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
-<event time="51283" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
-<event time="51283" type="arrival" person="1" link="1" legMode="car"/>
-<event time="51284" type="actstart" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="51284" type="actend" person="1" link="1" x="-25000" y="0" actType="car interaction"/>
-<event time="51284" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
-<event time="51284" type="travelled" person="1" distance="0" mode="walk"/>
-<event time="51284" type="arrival" person="1" link="1" legMode="walk"/>
-<event time="51285" type="actstart" person="1" link="1" x="-25000" y="0" actType="h"/>
+<event time="29400" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="29400" type="arrival" person="1" link="1" legMode="walk"/>
+<event time="29401" type="actstart" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="29401" type="actend" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="29401" type="departure" person="1" link="1" legMode="car" computationalRoutingMode="car"/>
+<event time="29401" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+<event time="29401" type="vehicle enters traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="29402" type="left link" link="1" vehicle="1_car"/>
+<event time="29402" type="entered link" link="2" vehicle="1_car"/>
+<event time="29762" type="left link" link="2" vehicle="1_car"/>
+<event time="29762" type="entered link" link="11" vehicle="1_car"/>
+<event time="29942" type="left link" link="11" vehicle="1_car"/>
+<event time="29942" type="entered link" link="20" vehicle="1_car"/>
+<event time="30301" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="30301" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+<event time="30301" type="arrival" person="1" link="20" legMode="car"/>
+<event time="30302" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="30302" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="30302" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="36920" type="travelled" person="1" distance="5514.6" mode="walk"/>
+<event time="36920" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="36921" type="actstart" person="1" link="20" x="3456" y="4242" actType="w"/>
+<event time="37521" type="actend" person="1" link="20" x="3456" y="4242" actType="w"/>
+<event time="37521" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="44139" type="travelled" person="1" distance="5514.6" mode="walk"/>
+<event time="44139" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="44140" type="actstart" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="44140" type="actend" person="1" link="20" x="3456" y="0" actType="car interaction"/>
+<event time="44140" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
+<event time="44140" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+<event time="44140" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="44140" type="vehicle leaves traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="44140" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+<event time="44140" type="arrival" person="1" link="20" legMode="car"/>
+<event time="44141" type="actstart" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="44141" type="actend" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="44141" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="51941" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="51941" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="51942" type="actstart" person="1" link="20" x="10000" y="0" actType="w"/>
+<event time="64542" type="actend" person="1" link="20" x="10000" y="0" actType="w"/>
+<event time="64542" type="departure" person="1" link="20" legMode="walk" computationalRoutingMode="car"/>
+<event time="72342" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="72342" type="arrival" person="1" link="20" legMode="walk"/>
+<event time="72343" type="actstart" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="72343" type="actend" person="1" link="20" x="5000" y="0" actType="car interaction"/>
+<event time="72343" type="departure" person="1" link="20" legMode="car" computationalRoutingMode="car"/>
+<event time="72343" type="PersonEntersVehicle" person="1" vehicle="1_car"/>
+<event time="72343" type="vehicle enters traffic" person="1" link="20" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="72344" type="left link" link="20" vehicle="1_car"/>
+<event time="72344" type="entered link" link="21" vehicle="1_car"/>
+<event time="72704" type="left link" link="21" vehicle="1_car"/>
+<event time="72704" type="entered link" link="22" vehicle="1_car"/>
+<event time="73964" type="left link" link="22" vehicle="1_car"/>
+<event time="73964" type="entered link" link="23" vehicle="1_car"/>
+<event time="74324" type="left link" link="23" vehicle="1_car"/>
+<event time="74324" type="entered link" link="1" vehicle="1_car"/>
+<event time="74683" type="vehicle leaves traffic" person="1" link="1" vehicle="1_car" networkMode="car" relativePosition="1"/>
+<event time="74683" type="PersonLeavesVehicle" person="1" vehicle="1_car"/>
+<event time="74683" type="arrival" person="1" link="1" legMode="car"/>
+<event time="74684" type="actstart" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="74684" type="actend" person="1" link="1" x="-20000" y="0" actType="car interaction"/>
+<event time="74684" type="departure" person="1" link="1" legMode="walk" computationalRoutingMode="car"/>
+<event time="82484" type="travelled" person="1" distance="6500" mode="walk"/>
+<event time="82484" type="arrival" person="1" link="1" legMode="walk"/>
+<event time="82485" type="actstart" person="1" link="1" x="-25000" y="0" actType="h"/>
 </events>

--- a/rust_qsim/tests/simulation/equil.rs
+++ b/rust_qsim/tests/simulation/equil.rs
@@ -1,3 +1,4 @@
+use crate::support::simulation_executor::TestExecutorBuilder;
 use macros::deterministic_id_test;
 use rust_qsim::external_services::routing::{
     InternalRoutingRequest, InternalRoutingRequestPayload, InternalRoutingResponse,
@@ -6,11 +7,6 @@ use rust_qsim::external_services::{
     AdapterHandle, AdapterHandleBuilder, AsyncExecutor, ExternalServiceType, RequestAdapter,
     RequestAdapterFactory,
 };
-use std::collections::HashMap;
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, Barrier};
-
-use crate::support::simulation_executor::TestExecutorBuilder;
 use rust_qsim::simulation::config::{CommandLineArgs, Config};
 use rust_qsim::simulation::controller::{ExternalServices, RequestSender};
 use rust_qsim::simulation::id::{Id, store_to_file};
@@ -22,6 +18,10 @@ use rust_qsim::simulation::scenario::population::{
 };
 use rust_qsim::simulation::scenario::vehicles::Garage;
 use rust_qsim::simulation::time::SimTime;
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Barrier};
+use tracing::info;
 
 // in the adaptive mod we are still using the binpb files
 fn create_resources<F>(out_dir: &Path, pop_adaption: F)
@@ -82,6 +82,24 @@ fn equil_two_parts_matches_expected_events() {
         .build()
         .unwrap()
         .execute();
+}
+
+#[deterministic_id_test(rust_qsim)]
+fn equil_full_population_single_part_runs() {
+    execute_equil_with_population(
+        "./tests/resources/equil/equil-config-1.yml",
+        "./assets/equil/equil-plans.xml.gz",
+        "./test_output/simulation/equil_full_population_single_part",
+    );
+}
+
+#[deterministic_id_test(rust_qsim)]
+fn equil_full_population_two_parts_runs() {
+    execute_equil_with_population(
+        "./tests/resources/equil/equil-config-2.yml",
+        "./assets/equil/equil-plans.xml.gz",
+        "./test_output/simulation/equil_full_population_two_parts",
+    );
 }
 
 #[deterministic_id_test(rust_qsim)]
@@ -215,6 +233,23 @@ impl RequestAdapter<InternalRoutingRequest> for MockRoutingAdapter {
             })
         );
     }
+}
+
+fn execute_equil_with_population(
+    config_path: impl Into<String>,
+    population_path: impl Into<PathBuf>,
+    output_dir: impl Into<PathBuf>,
+) {
+    let mut config = Config::from_args(CommandLineArgs::new_with_path(config_path.into()));
+    config.population_mut().path = Some(population_path.into());
+    config.output_mut().output_dir = output_dir.into();
+
+    TestExecutorBuilder::default()
+        .config(Arc::new(config))
+        .expected_events(None)
+        .build()
+        .unwrap()
+        .execute();
 }
 
 fn execute_adaptive(

--- a/rust_qsim/tests/simulation/equil.rs
+++ b/rust_qsim/tests/simulation/equil.rs
@@ -21,7 +21,6 @@ use rust_qsim::simulation::time::SimTime;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Barrier};
-use tracing::info;
 
 // in the adaptive mod we are still using the binpb files
 fn create_resources<F>(out_dir: &Path, pop_adaption: F)


### PR DESCRIPTION
This PR includes several changes: 
- travel time collector is now time bin based and ready to be used as `TravelTime` and `TravelDisutility`
- `move_nodes` behaves now like Java default impl
- `StuckTimer` is stored in the `SimNetworkPartition` instead of `LocalLink`
- storage capacity is fixed automatically in QSim, if it is to low (similar to java impl) 
- Zst compression is added
- dependencies have been updated